### PR TITLE
Deepcopy simulation dictionary

### DIFF
--- a/LDAR_Sim/model_code/ldar_sim_run.py
+++ b/LDAR_Sim/model_code/ldar_sim_run.py
@@ -21,6 +21,7 @@
 import os
 import sys
 import gc
+import copy
 import numpy as np
 import pandas as pd
 
@@ -37,6 +38,7 @@ def ldar_sim_run(simulation):
     simulation = a dictionary of simulation parameters necessary to run LDAR-Sim
     """
     # i = simulation['i']
+    simulation = copy.deepcopy (simulation)
     parameters = simulation['program']
     parameters['working_directory'] = simulation['wd']
     parameters['output_directory'] = os.path.join(


### PR DESCRIPTION
Prevent config changes in aircraft module from affecting other simulations.

In the aircraft company the follow up threshold logic on line 51 changes the config dict. In situations where there are many simulations being run, multiprocessing passes a list of simulation dictionaries to each process to run. When this change happens to the config dictionary, it changes it for all other simulations on the same process because the simulation dictionary is mutable. This is not an issue when only running a few simulations, and not an issue with lots of programs where each multiprocessing process will have a lot of diverse simulations to run, where the config dicts will be different and not affect each other.

This change prevents that by making the simulation dict 'read only' with a proper deepcopy. Another solution would be changing the aircraft company so it does not modify the config dictionary.

Thanks to Coleman for identifying this!