### PR TITLE
Delete output directory

### DIFF
--- a/LDAR_Sim/model_code/ldar_sim_main.py
+++ b/LDAR_Sim/model_code/ldar_sim_main.py
@@ -24,6 +24,7 @@ from batch_reporting import BatchReporting
 from ldar_sim_run import ldar_sim_run
 import pandas as pd
 import os
+import shutil
 import datetime
 import warnings
 import multiprocessing as mp
@@ -60,8 +61,10 @@ if __name__ == '__main__':
     # Check whether ERA5 data is already in the working directory and download data if not
     check_ERA5_file(wd, programs[0]['weather_file'])
 
-    if not os.path.exists(output_directory):
-        os.makedirs(output_directory)
+    if os.path.exists(output_directory):
+        shutil.rmtree(output_directory)
+
+    os.makedirs(output_directory)
 
     # Set up simulation parameter files
     simulations = []


### PR DESCRIPTION
Clean the output directory before running.

Changing the parameters of the simulation and re-running will leave old plots, old folders, etc. that don't correspond to the simulation you are running presently.

Cleaning the output directory ensures that whatever is in that folder corresponds to the latest simulation.

Thanks to Coleman for highlighting this!