### PR TITLE
Output directory conflicts

### DIFF
--- a/LDAR_Sim/model_code/ldar_sim_run.py
+++ b/LDAR_Sim/model_code/ldar_sim_run.py
@@ -46,7 +46,10 @@ def ldar_sim_run(simulation):
         simulation['output_directory'],
         parameters['program_name'])
     if not os.path.exists(parameters['output_directory']):
-        os.makedirs(parameters['output_directory'])
+        try:
+            os.makedirs(parameters['output_directory'])
+        except Exception:
+            pass
 
     logfile = open(os.path.join(parameters['output_directory'], 'logfile.txt'), 'w')
     if 'print_from_simulation' not in simulation or simulation['print_from_simulation']:


### PR DESCRIPTION
When running in parallel two processes simultaneously queue a filesystem call to create the output directory after both evaluating whether the output directory exists and both finding it doesn't exist, this causes a crash.

An alternative solution would be a tiny random sleep so two processes are not running at identical times.

This is a pretty rare bug, but happened this morning - so should be fixed. 

Probably exacerbated with platter disks (vs ssds) due to latency and batching of file system calls.

