### PR TITLE
fix basemap link

### DIFF
--- a/LDAR_Sim/model_code/Pipfile
+++ b/LDAR_Sim/model_code/Pipfile
@@ -10,7 +10,7 @@ numpy = "*"
 matplotlib = "*"
 pandas = "*"
 pyproj = {path = "../install/windows_python_wheels/pyproj-2.6.1.post1-cp37-cp37m-win_amd64.whl"}
-basemap = {file = "https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/basemap-1.2.1-cp37-cp37m-win_amd64.whl"}
+basemap = {file = "https://download.lfd.uci.edu/pythonlibs/r4tycu3t/basemap-1.2.2-cp37-cp37m-win_amd64.whl"}
 cftime = {path = "../install/windows_python_wheels/cftime-1.1.2-cp37-cp37m-win_amd64.whl"}
 netcdf4 = {path = "../install/windows_python_wheels/netCDF4-1.5.3-cp37-cp37m-win_amd64.whl"}
 xlrd = "*"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The easiest way to prepare your python installation is to use [pipenv](https://p
 `pipenv install`
 
 
-To make things easier, we have included windows binaries for the specific versions of cftime, GDAL, netCDF4, and pyproj. In the Pipfile, basemap is downloaded directly from [here](https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/basemap-1.2.1-cp37-cp37m-win_amd64.whl). If this link breaks or the package is no longer available, this is not a problem for base operations of LDAR-Sim as basemap is only used in the live plotter demonstration.
+To make things easier, we have included windows binaries for the specific versions of cftime, GDAL, netCDF4, and pyproj. In the Pipfile, basemap is downloaded directly from [here](https://download.lfd.uci.edu/pythonlibs/r4tycu3t/basemap-1.2.2-cp37-cp37m-win_amd64.whl). If this link breaks or the package is no longer available, this is not a problem for base operations of LDAR-Sim as basemap is only used in the live plotter demonstration.
 
 #### Step 2 Alternative: Using Requirements.txt
 An alternative approach to using the PIPfile and the prebuilt wheels is by using Conda (Conda-forge) and the requirements file included in the "install folder" Follow the directions included in the Setting Up LDAR Sim Dev Environment file. The requirements.txt file can also be used with PIP and pipenv, but Python and GDAL (versions listed in the requirements file) should be installed seperately.


### PR DESCRIPTION
Brought basemap up to 1.2.2 from 1.2.1 because 1.2.1 is no longer available, fixed the link. This is not a mission critical PR, but anyone installing will probably run into this and get discouraged. Ideally install works without errors, it makes Highwood and U of C look better.