### PR TITLE
Parameter refactor

### DIFF
--- a/LDAR-Sim_inputs.md
+++ b/LDAR-Sim_inputs.md
@@ -37,7 +37,7 @@ python ldar_sim_main.py parameter_file1.txt parameter_file2.txt
 
 ## Parameter File Structure
 
-Parameter files are all key-value pairs (e.g., Python dictionary), with multiple levels of nesting. In general, there are 3 layers of nesting:
+Parameter files are all key-value pairs (e.g., Python dictionary), with multiple levels of nesting. However, there are 3 important levels of nesting
 
 - `global`: global parameters that are common across the simulation such as system parameters, etc.
 - `program`: program parameters that relate to a specific emissions reduction program, of which there could be multiple within a given simulation.
@@ -86,7 +86,7 @@ parameters = {
 }
 ```
 
-Keep in mind that only 2 parameters have been changed with these parameter files - all other parameters run with the default values. We have attempted to choose representative defaults, but be aware the default values may not be what is appropriate for your use case.
+Keep in mind that only 2 parameters have been changed with these parameter files - all other parameters run with the default values. We have attempted to choose representative defaults, but be aware the default values may not be what is appropriate for your use case - it is your responsibility to verify the default parameters are appropriate.
 
 In this example, changing the `n_simulations` key to 3 makes the model run faster and provides a way to test the model without waiting for it to complete 30 simulations. A reasonable workflow with these parameters would be something like running the model in a test configuration with:
 
@@ -119,9 +119,9 @@ For example, running an existing program with an existing collection of methods 
 
 While global parameters are straightforward to specify this way, and the above example shows how to do this - a few extra parameters are required to directly specify programs or methods, which are at different levels in the hierarchy.
 
-## Specifying parent / child relationships and hierarchy
+## LDAR-Sim simulation hierarchy
 
-To tell LDAR-Sim what level in the hierarchy your parameter file is destined for, you can optionally specify a `parameter_level` parameter that will specify what level your parameter file is aimed at - otherwise LDAR-Sim will interpret it as global parameters.
+LDAR-Sim uses a 3 level hierarchy of simulations, programs, and methods. To tell LDAR-Sim what level in the hierarchy your parameter file is destined for, you should specify a `parameter_level` parameter that will specify what level your parameter file is aimed at - otherwise LDAR-Sim will interpret it as global parameters.
 
 The `parameter_level` parameter can be one of three values:
 
@@ -129,7 +129,11 @@ The `parameter_level` parameter can be one of three values:
 - `program`: parameters are used as a program definition.
 - `method`: parameters are used as a method definition.
 
-This `parameter_level` can also be supplemented by specification of the parent / child relationships among different parameter files. Here is the example simulation hierarchy from above:
+This `parameter_level` is vital to enable proper parameter validation.
+
+Methods require special consideration for several reasons. First, methods have `types`, that relate to specific method modules. For example, an OGI method is simulated using the OGI module. Users can build custom types or extend existing types, but some `type` is necessary to ensure LDAR-Sim knows what code to run. Second, there can be many different methods that are quite different, but have the same `type`. A good example is different OGI companies. You can run a simulation with multiple OGI companies, each specified as a unique method with unique agents, but both of the same type `OGI`. This is helpful to represent different work practices, different collection of parameters, or different approaches with the same technology. Third, because there are a large diversity of different methods in use, it is helpful to recycle the methods within different programs. Thus, methods can be implemented in different programs within the same simulation, but only specified once.
+
+To recycle methods, the programs must specify the methods by a name.
 
 ```buildoutcfg
 Global parameters
@@ -141,6 +145,9 @@ Programs:
         New LDAR method 2
 ```
 
+In LDAR Sim, to simplify, all supplied programs will be run in any 
+
+`Programs`
 In this example, `Global parameters` have no parent, they are the top level in the hierarchy. But global parameters have a number of programs as children, in this case `Reference program` and `Test program`. Both `Reference program` and `Test program` have the same parent, the `Global parameters`. The 3 different LDAR methods here have parents (the programs), but do not have children.
 
 These parent and child relationships can be specified within parameter files with the addition of several optional parameters:
@@ -215,6 +222,34 @@ LDAR-Sim includes a flexible input parameter mapper that accepts a variety of in
 - executable python files (extension = '.txt')
 - yaml files (extension = '.yaml' or '.yml')
 - json files (extension = '.json')
+
+## Notes for Developers
+
+If you are developing for LDAR-Sim, please adhere to the following rules:
+
+1. All parameters must be documented, refer to the examples below on the precise format.
+
+2. All parameters must sit in a key-value hierarchy that semantically makes sense.
+
+3. All parameters must have a defined type.
+
+4. If you are using the '.txt' format as a python dictionary of parameters that is executed, you must name the dictionary as a variable that is identical to the name of the file, minus the file extension.
+
+If your file name is ```P_ref.txt``` you must have a dictionary in the file that looks like this:
+
+```buildoutcfg
+P_ref = {
+    .... P_ref parameters ....
+}
+```
+
+Do not do this:
+
+```buildoutcfg
+some_other_name = {
+    .... P_ref parameters ....
+}
+```
 
 # General Inputs
 

--- a/LDAR_Sim/inputs_template/P_aircraft.txt
+++ b/LDAR_Sim/inputs_template/P_aircraft.txt
@@ -2,6 +2,7 @@ P_aircraft = {
         'methods': {
 	                 'aircraft': {
                             'name': 'aircraft',
+                            'type': 'aircraft',
                             'n_crews': 1,
                             'min_temp': -30,
                             'max_wind': 10,
@@ -19,6 +20,7 @@ P_aircraft = {
                             },
                    'OGI_FU': {
                             'name': 'OGI_FU',
+                            'type': 'OGI_FU',
                             'n_crews': 1,
             		    'min_temp': -20,
               		    'max_wind': 10,
@@ -30,6 +32,8 @@ P_aircraft = {
 			    'consider_daylight': False  
                             }
         },
+        'version': '2.0',
+        'parameter_level': 'program',
         'program_name': 'P_aircraft',
         'n_simulations': 2, 	# Minimum of 2 simulations to get batch plots
         'timesteps': 1000,  	# Up to ~5600 for 16 year nc file

--- a/LDAR_Sim/inputs_template/P_base.txt
+++ b/LDAR_Sim/inputs_template/P_base.txt
@@ -1,6 +1,8 @@
 P_base = {
         'methods': {
         },
+        'version': '2.0',
+        'parameter_level': 'program',
         'program_name': 'P_base',
         'n_simulations': 2, 	# Minimum of 2 simulations to get batch plots
         'timesteps': 1000,  	# Up to ~5600 for 16 year nc file

--- a/LDAR_Sim/inputs_template/P_cont.txt
+++ b/LDAR_Sim/inputs_template/P_cont.txt
@@ -2,6 +2,7 @@ P_cont = {
         'methods': {
 	                 'fixed': {
                             'name': 'fixed',
+                            'type': 'fixed',
                             'min_temp': -100,
                             'max_wind': 100,
                             'max_precip': 100,
@@ -28,6 +29,8 @@ P_cont = {
 			    'consider_daylight': False
                             }
         },
+        'version': '2.0',
+        'parameter_level': 'program',
         'program_name': 'P_cont',
         'n_simulations': 2, 	# Minimum of 2 simulations to get batch plots
         'timesteps': 1000,  	# Up to ~5600 for 16 year nc file

--- a/LDAR_Sim/inputs_template/P_ref.txt
+++ b/LDAR_Sim/inputs_template/P_ref.txt
@@ -2,6 +2,7 @@ P_ref = {
         'methods': {
             'OGI': {
                 'name': 'OGI',
+                'type': 'OGI',
                 'n_crews': 1,
                 'min_temp': -20,
                 'max_wind': 10,
@@ -13,6 +14,8 @@ P_ref = {
 		'consider_daylight': False 
             }
         },
+        'version': '2.0',
+        'parameter_level': 'program',
         'program_name': 'P_ref',
         'n_simulations': 2, 	# Minimum of 2 simulations to get batch plots
         'timesteps': 1000,  	# Up to ~5600 for 16 year nc file

--- a/LDAR_Sim/inputs_template/P_sat.txt
+++ b/LDAR_Sim/inputs_template/P_sat.txt
@@ -2,6 +2,7 @@ P_sat = {
         'methods': {
 	             'satellite': {
                             'name': 'satellite',
+                            'type': 'satellite',
 			    'sat':'GHGSAT-D',
                             'n_crews': 1,
 			    'min_temp': -100,
@@ -32,6 +33,8 @@ P_sat = {
 			    'consider_daylight': False  
                             }
         },
+        'version': '2.0',
+        'parameter_level': 'program',
         'program_name': 'P_sat',
         'n_simulations': 2, 	# Minimum of 2 simulations to get batch plots
         'timesteps': 1000,  	# Up to ~5600 for 16 year nc file

--- a/LDAR_Sim/inputs_template/P_truck.txt
+++ b/LDAR_Sim/inputs_template/P_truck.txt
@@ -2,6 +2,7 @@ P_truck = {
         'methods': {
                    'truck': {
                             'name': 'truck',
+                            'type': 'truck',
                             'n_crews': 1,
                             'min_temp': -40,
                             'max_wind': 20,
@@ -18,6 +19,7 @@ P_truck = {
                             },
                    'OGI_FU': {
                             'name': 'OGI_FU',
+                            'type': 'OGI_FU',
                             'n_crews': 1,
              		    'min_temp': -20,
                 	    'max_wind': 10,
@@ -29,6 +31,8 @@ P_truck = {
 			    'consider_daylight': False  
                             }
         },
+        'version': '2.0',
+        'parameter_level': 'program',
         'program_name': 'P_truck',
         'n_simulations': 2, 	# Minimum of 2 simulations to get batch plots
         'timesteps': 1000,  	# Up to ~5600 for 16 year nc file

--- a/LDAR_Sim/inputs_template/global_parameters.txt
+++ b/LDAR_Sim/inputs_template/global_parameters.txt
@@ -1,0 +1,15 @@
+parameters = {
+    'parameter_level': 'global',
+    'parent_name': 'global',
+    'parameter_version': '1.0',
+    'reference_program': 'P_ref',
+    'simulation_programs': ['P_ref', 'P_base'],
+    'wd': '..//inputs_template//',
+    'output_directory': '..//outputs//',
+    'n_processes':  None,
+    'print_from_simulations': True,
+    'n_simulations': 2,
+    'spin_up': 0,
+    'write_data':  True,
+    'additional_parameter_files': [],
+}

--- a/LDAR_Sim/inputs_template/global_parameters.txt
+++ b/LDAR_Sim/inputs_template/global_parameters.txt
@@ -1,8 +1,6 @@
-parameters = {
+global_parameters = {
+    'version': '2.0',
     'parameter_level': 'global',
-    'parent_name': 'global',
-    'parameter_version': '1.0',
-    'reference_program': 'P_ref',
     'wd': '..//inputs_template//',
     'output_directory': '..//outputs//',
     'n_processes':  None,
@@ -11,4 +9,8 @@ parameters = {
     'spin_up': 0,
     'write_data':  True,
     'programs': [],
+    'weather_file': "ERA5_AB_1x1_hourly_2015_2019.nc",
+    'timesteps': 1000,
+    'start_year': 2017,
+    'reference_program': 'P_ref',
 }

--- a/LDAR_Sim/inputs_template/global_parameters.txt
+++ b/LDAR_Sim/inputs_template/global_parameters.txt
@@ -3,7 +3,6 @@ parameters = {
     'parent_name': 'global',
     'parameter_version': '1.0',
     'reference_program': 'P_ref',
-    'simulation_programs': ['P_ref', 'P_base'],
     'wd': '..//inputs_template//',
     'output_directory': '..//outputs//',
     'n_processes':  None,
@@ -11,5 +10,5 @@ parameters = {
     'n_simulations': 2,
     'spin_up': 0,
     'write_data':  True,
-    'additional_parameter_files': [],
+    'programs': [],
 }

--- a/LDAR_Sim/model_code/Pipfile
+++ b/LDAR_Sim/model_code/Pipfile
@@ -10,13 +10,15 @@ numpy = "*"
 matplotlib = "*"
 pandas = "*"
 pyproj = {path = "../install/windows_python_wheels/pyproj-2.6.1.post1-cp37-cp37m-win_amd64.whl"}
-basemap = {file = "https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/basemap-1.2.1-cp37-cp37m-win_amd64.whl"}
+
 cftime = {path = "../install/windows_python_wheels/cftime-1.1.2-cp37-cp37m-win_amd64.whl"}
 netcdf4 = {path = "../install/windows_python_wheels/netCDF4-1.5.3-cp37-cp37m-win_amd64.whl"}
 xlrd = "*"
 plotnine = "*"
 ephem = "*"
 gdal = {path = "../install/windows_python_wheels/GDAL-3.0.4-cp37-cp37m-win_amd64.whl"}
+boto3 = "*"
+pyyaml = "*"
 
 [requires]
 python_version = "3.7"

--- a/LDAR_Sim/model_code/Pipfile.lock
+++ b/LDAR_Sim/model_code/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ab11a818a5c784070ac51a69043cafdc0e98fb9887dbf5d8b11e6cfe87f1b7f7"
+            "sha256": "12facbdb6bd6d5ef67347ef1c02aa0582aa0d45dc0c3e762745d69f2540de59b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,12 +16,20 @@
         ]
     },
     "default": {
-        "basemap": {
+        "boto3": {
             "hashes": [
-                "sha256:00293ace15b56e2e238a93ac63b8643770847ff10a8b6cd3227b438c760cfd4e"
+                "sha256:6300e9ee9a404038113250bd218e2c4827f5e676efb14e77de2ad2dcb67679bc",
+                "sha256:be4714f0475c1f5183eea09ddbf568ced6fa41b0fc9976f2698b8442e1b17303"
             ],
-            "path": "../install/windows_python_wheels/basemap-1.2.1-cp37-cp37m-win_amd64.whl",
-            "version": "==1.2.1"
+            "index": "pypi",
+            "version": "==1.17.102"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:2f57f7ceed1598d96cc497aeb45317db5d3b21a5aafea4732d0e561d0fc2a8fa",
+                "sha256:bdf08a4f7f01ead00d386848f089c08270499711447569c18d0db60023619c06"
+            ],
+            "version": "==1.20.102"
         },
         "cftime": {
             "hashes": [
@@ -63,35 +71,50 @@
         },
         "ephem": {
             "hashes": [
-                "sha256:0a6d6ed003383f702695094399728052981c567d423b25aa7163b3fd40de3d5a",
-                "sha256:189fcaeacb44dc5a1684ad489542f126d99d4a85e87d2fe73864c902f0bc2c71",
-                "sha256:1a8ea6a045ff669011f8ecdeffadfc5eaa519fb56ab8dd40508910e9db5ec7b0",
-                "sha256:1ff5abefa230d5ab40846f1cb27d4f5583d46044fecf10e17bfb559bdc766a47",
-                "sha256:2bcd953cced045e4232bcb71d60f6ba237f7944c880e83e74cc959449b192dee",
-                "sha256:31e2a17ca6f8d6bd44832574fea5461938ba034e52bf551e15e1a4c8f8c6c4fb",
-                "sha256:33ad1a71b204aff123250b04e0ff2d5c3b8e9c6c814bf2c675d7752ce5896c02",
-                "sha256:34fd228105b89fefd20608420861a75a184db1edeaf0056cf2f85d2a2f768aee",
-                "sha256:3530bee3eb7458d86d4c399f51f5b73ad7ea0441f0b2fb03de41d623789935af",
-                "sha256:36b51a8dc7cfdeb456dd6b8ab811accab8341b2d562ee3c6f4c86f6d3dbb984e",
-                "sha256:37fd1abbebb821381d2865064a6fa9484ffdcd2161cf92193da8d42da79aa7db",
-                "sha256:4bc5140cc7218a53ee6d949110f6ed413b8e3165294100515cd0fb29aa8e3637",
-                "sha256:71ea3935c658ee184575fd4cc2aa3e7fd6d6bac4a1ccff9ee5549cee67ff0385",
-                "sha256:72fdb72c813fc9780726aa732eb2193bbe1663549265ca5a746899215ecfbffd",
-                "sha256:7619297a1103f6b3dac0c609bfa7c31e17678fb1a02653347ec030487e412031",
-                "sha256:7f781d73e49caf7989c503a948471f1c8c1f738a450d557413999fb732f4dba3",
-                "sha256:8d586d970c42d62b1fc757a1c7c10679416a43e9e4a77391a05907159ce346f8",
-                "sha256:a5ddf46ced515e4b81dfd22e6408fd06a329c31c6abb10af48d392641c490b0e",
-                "sha256:c6081a9791e9de6511cddbeb9529bd5550fdb6f9e2a8dc9c2ec85911d67c6d11",
-                "sha256:e10c2c8afbb9e927d46d9bf3562441da2173ff196790a75ad0e5c5ee920d5922",
-                "sha256:e61c68f1c7d304a130bb6b88c1fca6600bbc1a1df6ca9a109b6eba4c6cbd3376",
-                "sha256:e73b9997d7b844fabff988d7f66c3bad4e76ec8975ec9c60ec988037bb5c04b1",
-                "sha256:f0959882bf73c8fe1cb801f42b0989e0ecb9d84b99eb8b8f70d61d16767a1e8a",
-                "sha256:f5af029f8814aa8617e73b2ddcad2bd1c682ca13c31ee3b6f5825dd5cb43e777",
-                "sha256:fd0b922387df1ad8721f2fafd5dca51ce7105238f968e1532a177b781b8cae0e",
-                "sha256:ff4e1584cc232d8bc4aea405346eeb8a24b0fbe84c6331d4edb5d4456d19f1c3"
+                "sha256:029dff6d8212ea9c63a8e34d1e0e416833b6b1888642ee0b7c69eb983f55eda7",
+                "sha256:02a0500965d624e0033f18e297afc80695f976d24eeb4f4c6c1c2edaae69d7df",
+                "sha256:065e0a36886e4dd03e8f3ccda44112f24557838332e45ca7844dd03f5f95f393",
+                "sha256:1066dd87d1d8a52cef8bed27c3135601d6124c5e9b25d989ab1f9f54461d674f",
+                "sha256:1670ef5b538c5a011e0aed92f3f71ce21f973c097d21c3953e9da9ee6577f0b4",
+                "sha256:1d5410a30977cc9c4b5d34b1fc9c450cfe3f0764c750fe8706276703ffb9faf4",
+                "sha256:1d5e33e5dfbdcb3c185f2b138037ef54d4a258478704ca8206a82a41db6e41fe",
+                "sha256:27fd1afa205b31fbfd3ed6618470b29738112b0bc07b330960ff95053446683e",
+                "sha256:2d679fbbc87161a9d48f462f972ce58b39e46df6a1025f55462478e86098cc52",
+                "sha256:32f534d418bd75d37fe9379508eef6bd58fdc4c6f5f8ccee8167a426c3dbae18",
+                "sha256:375e486e45bbfe2fae98e063d1963bddfff05e160fb17191da61b6fb03e37516",
+                "sha256:582ef4ffc52e9cb737291a4763aa28e3dfbad04d3713d88661311d8cfd9894c4",
+                "sha256:65e5dad6f47932ebb1a0f91af67fa1d6ef4bdfa25035f978c6e33002607c62b9",
+                "sha256:665485e788c7fc27d0885f8932346babe76d15def396179ead60ff7222b86165",
+                "sha256:669a664e020eacffe244f053ebdb67a7c2a0bade0297a8d58f9494043126ccdc",
+                "sha256:6732de67ea31d84ae091b1efb1a3c55eca6f0b9db2551f23e6fbe46cdb1340b0",
+                "sha256:6dd2c480ec6193e5f13e182605b4a6aa2fc682b9d4b24c95b16eb8706b27d548",
+                "sha256:6ddc93438de184b44397352fd204b6e08c264a70bf52862f1ae729a83f5b83cd",
+                "sha256:7383a7e119eebce8e1153f7deff1ee0c764ef339b57e0efe9787b0a60a8bee46",
+                "sha256:75736183d327da14afc99751bbdddc2bfa91b7f978f216f7ee7e404e8155903b",
+                "sha256:7be194fba66d682ea7144b43b42ff936e1900c2b714afa3c9dd48f167be9ecc9",
+                "sha256:86df088522ae40443649be14da0a584acc3c2e89676b523293437be9cf40908a",
+                "sha256:8d7febea4305f9257c28fe002dba531d8ee0f136d0e681a03dd9449459ab4ccb",
+                "sha256:a70b0b1d06256086422e2bb55fb8451bbd20c63144cba047cc174f4bb1035a61",
+                "sha256:b33d79e92b9c5a5f4f65fe35b337ea743518307eb8cb6f41b77430673da35332",
+                "sha256:be60729ca6569b1fbbdd34ad965f4d12aa739ce919b0b6182b0ac32c6fc2530a",
+                "sha256:c67ada1549928228b885ffe7264bdcd99321e0eade410ce9d74018a6cd3cf422",
+                "sha256:cc5fe92b349d072797d1297357a75f50daa662fca3c87fc0dcedb4edc5f39869",
+                "sha256:cef85182ec6f724b961d48a609ac50b45aaafe0d6c4e988ad2a42856149e8280",
+                "sha256:d03de73ebf6a91681d597eb5b5d43bcf6f0c67e292bba2f9a974734b4f15757e",
+                "sha256:d21ec00ba43d7034dd51594339eab786930a6ae0569a4b168cbb20932be0671c",
+                "sha256:dcd372ea57185ec12dc0bf9bc9fc57f00d8efd5291a742828731fb3840a789cb",
+                "sha256:e10fc9715abcc924dfffcde8438a7e0afe574ee99afc945a729fa88739fc3289",
+                "sha256:e1e4d92e04f187aaa1779f272778214b11f53456c0edbe29c7630a20fd5a29f0",
+                "sha256:ea90124c1e23cc599757ddfbd34ecef7452b82d2205e1abdb5ad6880ae74942b",
+                "sha256:ee47fcf845e94781672f84138e9d5b5f0ab3a9f46f8a63f6a49fddd9cb302cbc",
+                "sha256:f1d9fec04e41a8b00e366ba9c2aece5a937cd36504173f6310e7aeb218c2fc2c",
+                "sha256:f3461bdc9cbd986517379e16817a03ce2d579ab91f6b4dd9717e60a02a51a5ce",
+                "sha256:f38cf6f3696ba3ea0829de0c1dcc2a729b45938b3fc22db4081858aae4bd5b92",
+                "sha256:f5f76e5c65da92934946e76d093f68624645ba441102d7821a6d0f2d11ab655f",
+                "sha256:fa2163ed6562521a261f42d8a07d2b50991511f3e0725b1f64c07889fc9414ab"
             ],
             "index": "pypi",
-            "version": "==3.7.7.1"
+            "version": "==4.0.0.2"
         },
         "gdal": {
             "hashes": [
@@ -101,53 +124,81 @@
             "path": "../install/windows_python_wheels/GDAL-3.0.4-cp37-cp37m-win_amd64.whl",
             "version": "==3.0.4"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "version": "==0.10.0"
+        },
         "kiwisolver": {
             "hashes": [
-                "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c",
-                "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd",
-                "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f",
-                "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74",
-                "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1",
-                "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c",
-                "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec",
-                "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b",
-                "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7",
-                "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113",
-                "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec",
-                "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf",
-                "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e",
-                "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657",
-                "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8",
-                "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"
+                "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d",
+                "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31",
+                "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9",
+                "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0",
+                "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72",
+                "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3",
+                "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6",
+                "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e",
+                "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000",
+                "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3",
+                "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18",
+                "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21",
+                "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621",
+                "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b",
+                "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc",
+                "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131",
+                "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882",
+                "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454",
+                "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248",
+                "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de",
+                "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598",
+                "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54",
+                "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278",
+                "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6",
+                "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81",
+                "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030",
+                "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8",
+                "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689",
+                "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4",
+                "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0",
+                "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05",
+                "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.1"
         },
         "matplotlib": {
             "hashes": [
-                "sha256:2466d4dddeb0f5666fd1e6736cc5287a4f9f7ae6c1a9e0779deff798b28e1d35",
-                "sha256:282b3fc8023c4365bad924d1bb442ddc565c2d1635f210b700722776da466ca3",
-                "sha256:4bb50ee4755271a2017b070984bcb788d483a8ce3132fab68393d1555b62d4ba",
-                "sha256:56d3147714da5c7ac4bc452d041e70e0e0b07c763f604110bd4e2527f320b86d",
-                "sha256:7a9baefad265907c6f0b037c8c35a10cf437f7708c27415a5513cf09ac6d6ddd",
-                "sha256:aae7d107dc37b4bb72dcc45f70394e6df2e5e92ac4079761aacd0e2ad1d3b1f7",
-                "sha256:af14e77829c5b5d5be11858d042d6f2459878f8e296228c7ea13ec1fd308eb68",
-                "sha256:c1cf735970b7cd424502719b44288b21089863aaaab099f55e0283a721aaf781",
-                "sha256:ce378047902b7a05546b6485b14df77b2ff207a0054e60c10b5680132090c8ee",
-                "sha256:d35891a86a4388b6965c2d527b9a9f9e657d9e110b0575ca8a24ba0d4e34b8fc",
-                "sha256:e06304686209331f99640642dee08781a9d55c6e32abb45ed54f021f46ccae47",
-                "sha256:e20ba7fb37d4647ac38f3c6d8672dd8b62451ee16173a0711b37ba0ce42bf37d",
-                "sha256:f4412241e32d0f8d3713b68d3ca6430190a5e8a7c070f1c07d7833d8c5264398",
-                "sha256:ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee"
+                "sha256:0bea5ec5c28d49020e5d7923c2725b837e60bc8be99d3164af410eb4b4c827da",
+                "sha256:1c1779f7ab7d8bdb7d4c605e6ffaa0614b3e80f1e3c8ccf7b9269a22dbc5986b",
+                "sha256:21b31057bbc5e75b08e70a43cefc4c0b2c2f1b1a850f4a0f7af044eb4163086c",
+                "sha256:32fa638cc10886885d1ca3d409d4473d6a22f7ceecd11322150961a70fab66dd",
+                "sha256:3a5c18dbd2c7c366da26a4ad1462fe3e03a577b39e3b503bbcf482b9cdac093c",
+                "sha256:5826f56055b9b1c80fef82e326097e34dc4af8c7249226b7dd63095a686177d1",
+                "sha256:6382bc6e2d7e481bcd977eb131c31dee96e0fb4f9177d15ec6fb976d3b9ace1a",
+                "sha256:6475d0209024a77f869163ec3657c47fed35d9b6ed8bccba8aa0f0099fbbdaa8",
+                "sha256:6a6a44f27aabe720ec4fd485061e8a35784c2b9ffa6363ad546316dfc9cea04e",
+                "sha256:7a58f3d8fe8fac3be522c79d921c9b86e090a59637cb88e3bc51298d7a2c862a",
+                "sha256:7ad19f3fb6145b9eb41c08e7cbb9f8e10b91291396bee21e9ce761bb78df63ec",
+                "sha256:85f191bb03cb1a7b04b5c2cca4792bef94df06ef473bc49e2818105671766fee",
+                "sha256:956c8849b134b4a343598305a3ca1bdd3094f01f5efc8afccdebeffe6b315247",
+                "sha256:a9d8cb5329df13e0cdaa14b3b43f47b5e593ec637f13f14db75bb16e46178b05",
+                "sha256:b1d5a2cedf5de05567c441b3a8c2651fbde56df08b82640e7f06c8cd91e201f6",
+                "sha256:b26535b9de85326e6958cdef720ecd10bcf74a3f4371bf9a7e5b2e659c17e153",
+                "sha256:c541ee5a3287efe066bbe358320853cf4916bc14c00c38f8f3d8d75275a405a9",
+                "sha256:d8d994cefdff9aaba45166eb3de4f5211adb4accac85cbf97137e98f26ea0219",
+                "sha256:df815378a754a7edd4559f8c51fc7064f779a74013644a7f5ac7a0c31f875866"
             ],
             "index": "pypi",
-            "version": "==3.2.1"
+            "version": "==3.4.2"
         },
         "mizani": {
             "hashes": [
-                "sha256:2cdba487ee54faf3e5bfe0903155a13ff13d27a2dae709f9432194915b4fb1cd",
-                "sha256:da896b6c0e8868d411be0e46c72766596714869912359de44df269496ba9e29b"
+                "sha256:7f95d713e2bd28d51919e065d3453d470a654a0a219a7f777f8e9b6ed6e6ed35",
+                "sha256:f521300bd29ca918fcd629bc8ab50fa04e41bdbe00f6bcf74055d3c6273770a4"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.3"
         },
         "netcdf4": {
             "hashes": [
@@ -189,30 +240,37 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:00d7b54c025601e28f468953d065b9b121ddca7fff30bed7be082d3656dd798d",
-                "sha256:02ec9582808c4e48be4e93cd629c855e644882faf704bc2bd6bbf58c08a2a897",
-                "sha256:0e6f72f7bb08f2f350ed4408bb7acdc0daba637e73bce9f5ea2b207039f3af88",
-                "sha256:1be2e96314a66f5f1ce7764274327fd4fb9da58584eaff00b5a5221edefee7d6",
-                "sha256:2466fbcf23711ebc5daa61d28ced319a6159b260a18839993d871096d66b93f7",
-                "sha256:2b573fcf6f9863ce746e4ad00ac18a948978bb3781cffa4305134d31801f3e26",
-                "sha256:3f0dae97e1126f529ebb66f3c63514a0f72a177b90d56e4bce8a0b5def34627a",
-                "sha256:50fb72bcbc2cf11e066579cb53c4ca8ac0227abb512b6cbc1faa02d1595a2a5d",
-                "sha256:57aea170fb23b1fd54fa537359d90d383d9bf5937ee54ae8045a723caa5e0961",
-                "sha256:709c2999b6bd36cdaf85cf888d8512da7433529f14a3689d6e37ab5242e7add5",
-                "sha256:7d59f21e43bbfd9a10953a7e26b35b6849d888fc5a331fa84a2d9c37bd9fe2a2",
-                "sha256:904b513ab8fbcbdb062bed1ce2f794ab20208a1b01ce9bd90776c6c7e7257032",
-                "sha256:96dd36f5cdde152fd6977d1bbc0f0561bccffecfde63cd397c8e6033eb66baba",
-                "sha256:9933b81fecbe935e6a7dc89cbd2b99fea1bf362f2790daf9422a7bb1dc3c3085",
-                "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509",
-                "sha256:dccd380d8e025c867ddcb2f84b439722cf1f23f3a319381eac45fd077dee7170",
-                "sha256:e22cd0f72fc931d6abc69dc7764484ee20c6a60b0d0fee9ce0426029b1c1bdae",
-                "sha256:ed722aefb0ebffd10b32e67f48e8ac4c5c4cf5d3a785024fdf0e9eb17529cd9d",
-                "sha256:efb7ac5572c9a57159cf92c508aad9f856f1cb8e8302d7fdb99061dbe52d712c",
-                "sha256:efdba339fffb0e80fcc19524e4fdbda2e2b5772ea46720c44eaac28096d60720",
-                "sha256:f22273dd6a403ed870207b853a856ff6327d5cbce7a835dfa0645b3fc00273ec"
+                "sha256:1a784e8ff7ea2a32e393cc53eb0003eca1597c7ca628227e34ce34eb11645a0e",
+                "sha256:2ba579dde0563f47021dcd652253103d6fd66165b18011dce1a0609215b2791e",
+                "sha256:3537b967b350ad17633b35c2f4b1a1bbd258c018910b518c30b48c8e41272717",
+                "sha256:3c40e6b860220ed862e8097b8f81c9af6d7405b723f4a7af24a267b46f90e461",
+                "sha256:598fe100b2948465cf3ed64b1a326424b5e4be2670552066e17dfaa67246011d",
+                "sha256:620732f42259eb2c4642761bd324462a01cdd13dd111740ce3d344992dd8492f",
+                "sha256:709884863def34d72b183d074d8ba5cfe042bc3ff8898f1ffad0209161caaa99",
+                "sha256:75579acbadbf74e3afd1153da6177f846212ea2a0cc77de53523ae02c9256513",
+                "sha256:7c55407f739f0bfcec67d0df49103f9333edc870061358ac8a8c9e37ea02fcd2",
+                "sha256:a1f2fb2da242568af0271455b89aee0f71e4e032086ee2b4c5098945d0e11cf6",
+                "sha256:a290989cd671cd0605e9c91a70e6df660f73ae87484218e8285c6522d29f6e38",
+                "sha256:ac4fd578322842dbda8d968e3962e9f22e862b6ec6e3378e7415625915e2da4d",
+                "sha256:ad09f55cc95ed8d80d8ab2052f78cc21cb231764de73e229140d81ff49d8145e",
+                "sha256:b9205711e5440954f861ceeea8f1b415d7dd15214add2e878b4d1cf2bcb1a914",
+                "sha256:bba474a87496d96e61461f7306fba2ebba127bed7836212c360f144d1e72ac54",
+                "sha256:bebab3eaf0641bba26039fb0b2c5bf9b99407924b53b1ea86e03c32c64ef5aef",
+                "sha256:cc367c86eb87e5b7c9592935620f22d13b090c609f1b27e49600cd033b529f54",
+                "sha256:ccc6c650f8700ce1e3a77668bb7c43e45c20ac06ae00d22bdf6760b38958c883",
+                "sha256:cf680682ad0a3bef56dae200dbcbac2d57294a73e5b0f9864955e7dd7c2c2491",
+                "sha256:d2910d0a075caed95de1a605df00ee03b599de5419d0b95d55342e9a33ad1fb3",
+                "sha256:d5caa946a9f55511e76446e170bdad1d12d6b54e17a2afe7b189112ed4412bb8",
+                "sha256:d89b0dc7f005090e32bb4f9bf796e1dcca6b52243caf1803fdd2b748d8561f63",
+                "sha256:d95d16204cd51ff1a1c8d5f9958ce90ae190be81d348b514f9be39f878b8044a",
+                "sha256:e4d5a86a5257843a18fb1220c5f1c199532bc5d24e849ed4b0289fb59fbd4d8f",
+                "sha256:e58ddb53a7b4959932f5582ac455ff90dcb05fac3f8dcc8079498d43afbbde6c",
+                "sha256:e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce",
+                "sha256:eda2829af498946c59d8585a9fd74da3f810866e05f8df03a86f70079c7531dd",
+                "sha256:fd0a359c1c17f00cb37de2969984a74320970e0ceef4808c32e00773b06649d9"
             ],
             "index": "pypi",
-            "version": "==1.18.4"
+            "version": "==1.21.0"
         },
         "palettable": {
             "hashes": [
@@ -223,25 +281,27 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835",
-                "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722",
-                "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266",
-                "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645",
-                "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5",
-                "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4",
-                "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a",
-                "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586",
-                "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b",
-                "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c",
-                "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b",
-                "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85",
-                "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5",
-                "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639",
-                "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e",
-                "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"
+                "sha256:0c34b89215f984a9e4956446e0a29330d720085efa08ea72022387ee37d8b373",
+                "sha256:0dbd125b0e44e5068163cbc9080a00db1756a5e36309329ae14fd259747f2300",
+                "sha256:1102d719038e134e648e7920672188a00375f3908f0383fd3b202fbb9d2c3a95",
+                "sha256:14abb8ea73fce8aebbb1fb44bec809163f1c55241bcc1db91c2c780e97265033",
+                "sha256:25fc8ef6c6beb51c9224284a1ad89dfb591832f23ceff78845f182de35c52356",
+                "sha256:38e7486410de23069392bdf1dc7297ae75d2d67531750753f3149c871cd1c6e3",
+                "sha256:4bfbf62b00460f78a8bc4407112965c5ab44324f34551e8e1f4cac271a07706c",
+                "sha256:78de96c1174bcfdbe8dece9c38c2d7994e407fd8bb62146bb46c61294bcc06ef",
+                "sha256:7b09293c7119ab22ab3f7f086f813ac2acbfa3bcaaaeb650f4cddfb5b9fa9be4",
+                "sha256:821d92466fcd2826656374a9b6fe4f2ec2ba5e370cce71d5a990577929d948df",
+                "sha256:9244fb0904512b074d8c6362fb13aac1da6c4db94372760ddb2565c620240264",
+                "sha256:94ca6ea3f46f44a979a38a4d5a70a88cee734f7248d7aeeed202e6b3ba485af1",
+                "sha256:a67227e17236442c6bc31c02cb713b5277b26eee204eac14b5aecba52492e3a3",
+                "sha256:c862cd72353921c102166784fc4db749f1c3b691dd017fc36d9df2c67a9afe4e",
+                "sha256:d9e6edddeac9a8e473391d2d2067bb3c9dc7ad79fd137af26a39ee425c2b4c78",
+                "sha256:e36515163829e0e95a6af10820f178dd8768102482c01872bff8ae592e508e58",
+                "sha256:f20e4b8a7909f5a0c0a9e745091e3ea18b45af9f73496a4d498688badbdac7ea",
+                "sha256:fc9215dd1dd836ff26b896654e66b2dfcf4bbb18aa4c1089a79bab527b665a90"
             ],
             "index": "pypi",
-            "version": "==1.0.3"
+            "version": "==1.2.5"
         },
         "patsy": {
             "hashes": [
@@ -250,13 +310,52 @@
             ],
             "version": "==0.5.1"
         },
+        "pillow": {
+            "hashes": [
+                "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5",
+                "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4",
+                "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9",
+                "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a",
+                "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9",
+                "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727",
+                "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120",
+                "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c",
+                "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2",
+                "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797",
+                "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b",
+                "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f",
+                "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef",
+                "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232",
+                "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb",
+                "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9",
+                "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812",
+                "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178",
+                "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291",
+                "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b",
+                "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5",
+                "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b",
+                "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1",
+                "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713",
+                "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4",
+                "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484",
+                "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c",
+                "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9",
+                "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388",
+                "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d",
+                "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602",
+                "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9",
+                "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e",
+                "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"
+            ],
+            "version": "==8.2.0"
+        },
         "plotnine": {
             "hashes": [
-                "sha256:aae2c8164abb209ef4f28cab01132d23f6879fcf8d492657487359e1241459e5",
-                "sha256:c271d08edf276f6be09951a4544a1116fc7aa6bc68cadef1b05e29c26ff5f683"
+                "sha256:39de59edcc28106761b65238647d0b1f6212ea7f3a78f8be0b846616db969276",
+                "sha256:3c938093e20c6e68d1ee4591967a2e5093d185046bad88af00af81bf14215549"
             ],
             "index": "pypi",
-            "version": "==0.6.0"
+            "version": "==0.8.0"
         },
         "pyparsing": {
             "hashes": [
@@ -294,12 +393,6 @@
             "path": "../install/windows_python_wheels/pyproj-2.6.1.post1-cp37-cp37m-win_amd64.whl",
             "version": "==2.6.1.post1"
         },
-        "pyshp": {
-            "hashes": [
-                "sha256:e65c7f24d372b97d0920b864bbeb78322bb37b83f2606e2a2212631d5d51e5c0"
-            ],
-            "version": "==2.1.0"
-        },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
@@ -309,77 +402,124 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
-                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
-            "version": "==2020.1"
+            "version": "==2021.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc",
+                "sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2"
+            ],
+            "version": "==0.4.2"
         },
         "scipy": {
             "hashes": [
-                "sha256:00af72998a46c25bdb5824d2b729e7dabec0c765f9deb0b504f928591f5ff9d4",
-                "sha256:0902a620a381f101e184a958459b36d3ee50f5effd186db76e131cbefcbb96f7",
-                "sha256:1e3190466d669d658233e8a583b854f6386dd62d655539b77b3fa25bfb2abb70",
-                "sha256:2cce3f9847a1a51019e8c5b47620da93950e58ebc611f13e0d11f4980ca5fecb",
-                "sha256:3092857f36b690a321a662fe5496cb816a7f4eecd875e1d36793d92d3f884073",
-                "sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa",
-                "sha256:71eb180f22c49066f25d6df16f8709f215723317cc951d99e54dc88020ea57be",
-                "sha256:770254a280d741dd3436919d47e35712fb081a6ff8bafc0f319382b954b77802",
-                "sha256:787cc50cab3020a865640aba3485e9fbd161d4d3b0d03a967df1a2881320512d",
-                "sha256:8a07760d5c7f3a92e440ad3aedcc98891e915ce857664282ae3c0220f3301eb6",
-                "sha256:8d3bc3993b8e4be7eade6dcc6fd59a412d96d3a33fa42b0fa45dc9e24495ede9",
-                "sha256:9508a7c628a165c2c835f2497837bf6ac80eb25291055f56c129df3c943cbaf8",
-                "sha256:a144811318853a23d32a07bc7fd5561ff0cac5da643d96ed94a4ffe967d89672",
-                "sha256:a1aae70d52d0b074d8121333bc807a485f9f1e6a69742010b33780df2e60cfe0",
-                "sha256:a2d6df9eb074af7f08866598e4ef068a2b310d98f87dc23bd1b90ec7bdcec802",
-                "sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408",
-                "sha256:c5cac0c0387272ee0e789e94a570ac51deb01c796b37fb2aad1fb13f85e2f97d",
-                "sha256:cc971a82ea1170e677443108703a2ec9ff0f70752258d0e9f5433d00dda01f59",
-                "sha256:dba8306f6da99e37ea08c08fef6e274b5bf8567bb094d1dbe86a20e532aca088",
-                "sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521",
-                "sha256:dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59"
+                "sha256:0572256c10ddd058e3d315c555538671ddb2737f27eb56189bfbc3483391403f",
+                "sha256:2e685fdbfa5b989af4338b29c408b9157ea6addec15d661104c437980c292be5",
+                "sha256:3595c8b64970c9e5a3f137fa1a9eb64da417e78fb7991d0b098b18a00b776d88",
+                "sha256:3e7df79b42c3015058a5554bfeab6fd4c9906c46560c9ddebb5c652840f3e182",
+                "sha256:4ef3d4df8af40cb6f4d4eaf7b02780109ebabeec334cda26a7899ec9d8de9176",
+                "sha256:53116abd5060a5b4a58489cf689bee259b779e6b7ecd4ce366e7147aa7c9626e",
+                "sha256:5a983d3cebc27294897951a494cebd78af2eae37facf75d9e4ad4f1f62229860",
+                "sha256:5eb8f054eebb351af7490bbb57465ba9662c4e16e1786655c6c7ed530eb9a74e",
+                "sha256:6130e22bf6ee506f7cddde7e0515296d97eb6c6c94f7ef5103c2b77aec5833a7",
+                "sha256:7f4b89c223bd09460b52b669e2e642cab73c28855b540e6ed029692546a86f8d",
+                "sha256:80df8af7039bce92fb4cd1ceb056258631b11b3c627384e2d29bb48d44c0cae7",
+                "sha256:821e75f5c16cd7b0ab0ffe7eb9917e5af7b48c25306b4777287de8d792a5f7f3",
+                "sha256:97ca4552ace1c313707058e774609af59644321e278c3a539322fab2fb09b943",
+                "sha256:998c5e6ea649489302de2c0bc026ed34284f531df89d2bdc8df3a0d44d165739",
+                "sha256:aef6e922aea6f2e6bbb539b413c85210a9ee32757535b84204ebd22723e69704",
+                "sha256:b77ee5e3a9507622e7f98b16122242a3903397f98d1fe3bc269d904a9025e2bc",
+                "sha256:bd4399d4388ca0239a4825e312b3e61b60f743dd6daf49e5870837716502a92a",
+                "sha256:c5d012cb82cc1dcfa72609abaabb4a4ed8113e3e8ac43464508a418c146be57d",
+                "sha256:e7b733d4d98e604109715e11f2ab9340eb45d53f803634ed730039070fc3bc11"
             ],
-            "version": "==1.4.1"
+            "version": "==1.7.0"
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "version": "==1.14.0"
+            "version": "==1.16.0"
         },
         "statsmodels": {
             "hashes": [
-                "sha256:02e95c567ac77834210ecbe96a64eb939fc42669f95d583ac6184b00830db743",
-                "sha256:1e3ae5671cae0da8f94ce5e9331fc9880fe6210ffd5750ac961f84203d262763",
-                "sha256:434240abd14f4998ec6350473cd105e9977e930635ecf7e352d641d729dbc2a2",
-                "sha256:47e0f27fe515fae06240a1f1dbcdce8b93417ea294b4965335f538627f711b10",
-                "sha256:49aa8ffbe0b0e2e86afa58dec6bd5c483898e9b8223d8a7d13b69b5ad144b674",
-                "sha256:59403da80bdba84713d93f36897fba4fd3b2964a1b983816ed488a405abc18b1",
-                "sha256:5bde3fa0a35a91b45dba7cbc28270b5b649ff1d721c89290883f6e831672d5f0",
-                "sha256:5e7afc596164c1c7464ba3943721a9668aa0ce07853ce9881ac49d3a043784dd",
-                "sha256:621f2ec00ff8a4749cef3c9cc11c12ac2ee549ecf3ccfde626b3f1461165f0e6",
-                "sha256:6243bc78bc805acee7690098fa749094895bb3c2dd0b7f7ac8d57f97fe2b1eb2",
-                "sha256:6371267d051b555898611913afa4a46144e9d29a234ef32c2e36e558e88a8de9",
-                "sha256:67e1a5d9fc6900209203cd446b2ed6822eb4b03581dea669c4fe97f512cfde36",
-                "sha256:6e7e2cb74d8ae56cffc0581f3467cdcd16d8f7e97297974cefdf0d727020c287",
-                "sha256:92536c3579a6c7fbdaeb1c026781a17d4760e4b76ca861eaae05b2a43309dca5",
-                "sha256:9efd2e27c08077330cecdbfb589cf84d735abface94e9a6387282a6a7c91362d",
-                "sha256:a4fcb03d2a5d0f37d0ecb38f6d9d10a3ab6f9e2e583c3be4d4615484d5d10e88",
-                "sha256:b9b9cb6ced4f9b644cfd0b6a9d4a88e406c643dba4f2ad61e22d03ee48bc7731",
-                "sha256:bce1e6b94ade985a8319621c9ea4f7e312ed8cfcb5d93ab0cb0013c58b98680c",
-                "sha256:e728156ae279f05574ef9e840ec57f44c96c85ba14010169e9b4e1085d89642f",
-                "sha256:f2ac0559d6ef824d5a47576f572de62b0f088ef4f912dd40298ee9ab20d3ef9b",
-                "sha256:f5e4928e230332260cb55458953dbbae6a63356f91d3242c7ba2d17dc6c4bd7f"
+                "sha256:0197855aa1d40c42532d6a75b4ca72e30826a50d90ec3047a404f9702d8b814f",
+                "sha256:1fa720e895112a1b04b27002218b0ea7f10dd1d9cffd1c018c88bbfb82520f57",
+                "sha256:37e107fa11299090ed90f93c7172162b850c28fd09999937b971926813e887c5",
+                "sha256:3aab85174444f1bcad1e9218a3d3db08f0f86eeb97985236ca8605a0a39ce305",
+                "sha256:3e94306d4c07e332532ea4911d1f1d1f661c79aa73f22c5bb22e6dd47b40d562",
+                "sha256:4184487e9c281acad3d0bda19445c69db292f0dbb18f25ebf56a7966a0a28eef",
+                "sha256:43de84bc08c8b9f778502aed7a476d6e68674e6878718e533b07d569cf0927a9",
+                "sha256:587deb788e7f8f3f866d28e812cf5c082b4d4a2d3f5beea94d0e9699ea71ef22",
+                "sha256:5d3e7333e1c5b234797ed57c3d1533371374c1e1e7e7ed54d27805611f96e2d5",
+                "sha256:8ad7a7ae7cdd929095684118e3b05836c0ccb08b6a01fe984159475d174a1b10",
+                "sha256:8f93cb3f7d87c1fc7e51b3b239371c25a17a0a8e782467fdf4788cfef600724a",
+                "sha256:93273aa1c31caf59bcce9790ca4c3f54fdc45a37c61084d06f1ba4fbe56e7752",
+                "sha256:94d3632d56c13eebebaefb52bd4b43144ad5a131337b57842f46db826fa7d2d3",
+                "sha256:a3bd3922463dda8ad33e5e5075d2080e9e012aeb2032b5cdaeea9b79c2472000",
+                "sha256:aaf3c75fd22cb9dcf9c1b28f8ae87521310870f4dd8a6a4f1010f1e46d992377",
+                "sha256:c1d98ce2072f5e772cbf91d05475490368da5d3ee4a3150062330c7b83221ceb",
+                "sha256:c3782ce846a52862ac72f89d22b6b1ca13d877bc593872309228a6f05d934321",
+                "sha256:c48b7cbb37a651bb1cd23614abc10f447845ad3c3a713bf74e2aad20cfc94ae7",
+                "sha256:cbbdf6f708c9a1f1fad5cdea5e4342d6fdb37e42e92288c2cf906b99976ffe15",
+                "sha256:f3a7622f3d0ce2fc204f43b74de4e03e42775609705bf94d656b730482ca935a",
+                "sha256:f61f33f64760a22100b6b146217823f73cfedd251c9bdbd58453ca94e63326c7"
             ],
-            "version": "==0.11.1"
+            "version": "==0.12.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+            ],
+            "version": "==1.26.6"
         },
         "xlrd": {
             "hashes": [
-                "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2",
-                "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"
+                "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd",
+                "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"
             ],
             "index": "pypi",
-            "version": "==1.2.0"
+            "version": "==2.0.1"
         }
     },
     "develop": {}

--- a/LDAR_Sim/model_code/input_manager.py
+++ b/LDAR_Sim/model_code/input_manager.py
@@ -18,49 +18,59 @@
 # along with this program.  If not, see <https://opensource.org/licenses/MIT>.
 #
 # ------------------------------------------------------------------------------
+
 import copy
 import os
 import yaml
 import json
 import glob
 import sys
+import time
 
-def check_types (default, test, omit_keys = [], fatal = False):
+from input_mapper_v1 import input_mapper_v1
+
+
+def check_types(default, test, omit_keys = None, fatal = False):
     """Helper function to recursively check the type of parameter dictionaries
 
     :param default: default element to test
     :param test: test element to test
-    :omit_keys: a list of dictionary keys to omit from further recursive testing
+    :param omit_keys: a list of dictionary keys to omit from further recursive testing
     :param fatal: boolean to control whether sys.exit() is called upon a error
     """
+    # Infer 'None' to an empty list
+    if omit_keys is None:
+        omit_keys = []
+
     if type(default) is type(test):
-        # proceed to test for dict or list types to recursively examine
+        # Proceed to test for dict or list types to recursively examine
         if isinstance(test, dict):
             for i in test:
-                if not i in omit_keys:
-                    if not i in default:
+                if i not in omit_keys:
+                    if i not in default:
                         print('Key ' + i + ' present in test parameters, but not in default parameters')
                         if fatal:
                             sys.exit()
 
                     else:
-                        check_types(default[i], test[i], fatal)
+                        check_types(default[i], test[i], omit_keys = omit_keys, fatal = fatal)
 
         elif isinstance(test, list):
             if len(test) > 0:
                 for i in range(len(test)):
-                    check_types(default[0], test[i], fatal)
+                    check_types(default[0], test[i], omit_keys = omit_keys, fatal = fatal)
 
     else:
         print('Parameter type mismatch')
-        print('Default parameter: ' + str(default) + ' is ' + type(default))
-        print('Test parameter: ' + str(test) + ' is ' + type(test))
+        print('Default parameter: ' + str(default) + ' is ' + str(type(default)))
+        print('Test parameter: ' + str(test) + ' is ' + str(type(test)))
         if fatal:
             sys.exit()
 
-class input_manager:
-    def __init__ (self, global_parameter_filename = '..//inputs_template//global_parameters.txt',
-                  program_parameter_filenames = None):
+
+class InputManager:
+    def __init__(self, global_parameter_filename = '..//inputs_template//global_parameters.txt',
+                 program_parameter_filenames = None):
         """ Constructor loads the input parameters in a format that is compliant with the internals of LDAR-Sim. These
         parameters are subsequently modified by one or more input parameters.
 
@@ -75,7 +85,7 @@ class input_manager:
         The format of the default parameters is .txt, or .py, that gets read, and executed directly as
         python code. This is to ensure reverse compatibility with the existing set of parameters and also to ensure
         that the type are explicitly set with python code, where type setting is easier to understand and less subject
-        to possible issues with json or yaml parsers inferring incorrect types.
+        to possible issues with json or yaml parsers inferring types.
 
         :param global_parameter_filename: filename for global parameters. Defaults to
             '..//inputs_template//global_parameters.txt'
@@ -100,33 +110,34 @@ class input_manager:
             self.method_parameters['OGI'] will return a full listing of all OGI parameters that is subsequently used
             for type validation and provide the base of default parameters to build upon.
         """
-
         # Check if program parameter filenames were supplied, else try to read them in
         if program_parameter_filenames is None:
             program_parameter_filenames = glob.glob('..//inputs_template//P_*.txt')
 
-        # Read in default parameters
+        # Assemble the default parameters
         # 1) read in global parameters, this sets a local variable called 'parameters'
         with open(global_parameter_filename, 'r') as f:
-            exec(f.read())
+            exec(f.read(), globals())
 
         # 2) read in the program definitions, which contain method definitions
         for parameter_filename in program_parameter_filenames:
             with open(parameter_filename, 'r') as f:
                 program_definition, _ = os.path.splitext(os.path.basename(parameter_filename))
                 exec(f.read())
-                if not program_definition in locals():
+                if program_definition not in locals():
                     print(program_definition + ' is not defined in ' + parameter_filename)
 
-                parameters['programs'].append(eval(program_definition))
+                global_parameters['programs'].append(eval(program_definition))
 
         # 3) separate programs from methods and construct a default program with all possible parameters. This
         #    accumulates a list of method definitions from the programs to conflate to a unique list of method
         #    definitions.
         self.program_parameters = {'methods': []}
         temp_methods = []
-        for program in parameters['programs']:
-            temp_methods.append(program.pop['methods'])
+        for program in global_parameters['programs']:
+            if len(program['methods']) > 0:
+                temp_methods.append(program.pop('methods'))
+
             self.program_parameters.update(program)
 
         # 4) accumulate the method samples so there is a dictionary of possible method types, each with all
@@ -135,106 +146,66 @@ class input_manager:
         for method_samples in temp_methods:
             for i in method_samples:
                 # Address an issue where 'type' is not specified, allow reverse compatibility by using the name
-                if not 'type' in method_samples[i]:
+                if 'type' not in method_samples[i]:
                     method_samples[i]['type'] = i
 
                 self.method_parameters.update({method_samples[i]['type']: method_samples[i]})
 
         # 5) set default global parameters, programs and methods are dealt with separately
-        parameters['programs'] = []
-        self.global_parameters = parameters
+        global_parameters['programs'] = []
+        self.global_parameters = global_parameters
+
+        # 6) construct simulation parameters, which will be updated and returned
+        self.simulation_parameters = copy.deepcopy(self.global_parameters)
         return
 
-    def read_and_validate_parameters (self, parameter_filenames):
+    def read_and_validate_parameters(self, parameter_filenames):
         """Method to read and validate parameters
         :param parameter_filenames: a list of paths to parameter files
         :return returns fully validated parameters dictionary for simulation in LDAR-Sim
         """
-        unvalidated_parameters = self.read_parameter_files(parameter_filenames)
-        validated_parameters = self.parse_parameters(unvalidated_parameters)
-        return(validated_parameters)
+        raw_parameters = self.read_parameter_files(parameter_filenames)
+        self.parse_parameters(raw_parameters)
 
-    def parse_parameters (self, new_parameters_list):
-        """Method to parse and validate new parameters, perform type checking, and organize for simulation.
+        # Coerce all paths to absolute paths prior to release, add extra guards for other parts of the code
+        # that concatenate strings to construct file paths, and expect trailing slashes
+        self.simulation_parameters['wd'] = os.path.abspath(self.simulation_parameters['wd']) + '//'
+        self.simulation_parameters['output_directory'] = os.path.abspath(self.simulation_parameters['output_directory']) + '//'
+        return(copy.deepcopy(self.simulation_parameters))
 
-        This first goes through the new parameters, sorts out the programs and orphaned methods (methods that are
-        not directly integrated to a program).
+    def write_parameters(self, filename):
+        """Method to write simulation parameters to the file system
 
-        Programs are then addressed, consecutively adding them in, calling in any orphaned methods. Orphaned methods
-        can be used in multiple programs if desired.
-
-        :param new_parameters_list: a list of new parameter dictionaries
-        :return returns the validated parameters
+        :param filename: filename to write the parameters to
         """
-        # First, validate and install the global parameters, saving the programs and orphaned methods for the next step
-        programs = []
-        orphan_methods = []
-        for new_parameters in new_parameters_list:
-            # Address unsupplied
-            if not 'parameter_level' in new_parameters:
-                new_parameters['parameter_level'] = 'global'
-                print('Warning: parameter_level should be supplied to parameter files, LDAR-Sim interprets parameter'
-                      'files as global if unspecified')
+        with open(filename, 'w') as f:
+            f.write(yaml.dump(self.simulation_parameters))
 
-            if new_parameters['parameter_level'] == 'global':
-                programs.append(new_parameters.pop('programs'))
-                check_types(self.global_parameters, new_parameters, omit_keys = ['programs', 'methods'])
-                self.global_parameters.update(new_parameters)
+    def read_parameter_files(self, parameter_filenames):
+        """Method to read a collection of parameter files and perform any mapping prior to validation.
 
-            elif new_parameters['parameter_level'] == 'program':
-                check_types(self.program_parameters, new_parameters, omit_keys = ['methods'])
-
-                # Copy all default program parameters to build upon by calling update, then append
-                new_program = copy.deepcopy(self.program_parameters)
-                new_program.update(new_parameters)
-                programs.append(new_program)
-
-            elif new_parameters['parameter_level'] == 'method':
-                orphan_methods.append(new_parameters)
-
-            else:
-                sys.exit('supplied parameter_level is not possible to parse')
-
-        # Second, install the programs, checking for specified children methods
-        for program in programs:
-            # Find any orphaned methods that can be installed in this program
-            if 'method_names' in program:
-                for method_name in program['method_names']:
-                    method_found = False
-                    for i in orphan_methods:
-                        if method_name == orphan_methods[i]:
-                            program['methods'].update (copy.deepcopy(orphan_methods[i]))
-                            method_found = True
-
-                    if not method_found:
-                        print('Warning, the following method was specified by not supplied ' + method_name)
-
-            # Next, perform type checking and updating from default types, even for methods pre-specified
-            for i in program['methods']:
-                method_type = program['methods'][i]['type']
-                check_types(self.method_parameters[method_type], program['methods'][i])
-                new_method = copy.deepcopy(self.method_parameters[method_type])
-
-                # update from the default version, and re-assign
-                new_method.update(program['methods'][i])
-                program['methods'][i] = new_method
-
-        # Third, append the parameters to the global parameters and return a copy
-        self.global_parameters['programs'] = programs
-        return(copy.deepcopy(self.global_parameters))
-
-    def read_parameter_files (self, parameter_filenames):
-        """Method to read a collection of parameter files
         :param parameter_filenames: a list of paths to parameter files
         :return returns a list of parameter dictionaries
         """
+        # Read in the parameter files
         new_parameters_list = []
         for parameter_filename in parameter_filenames:
             new_parameters_list.append(self.read_parameter_file(parameter_filename))
 
+        # Perform any mapping, optionally accumulating mined global parameters
+        global_parameters = {}
+        for i in range(len(new_parameters_list)):
+            new_parameters_list[i], mined_global_parameters = self.map_parameters(new_parameters_list[i])
+            global_parameters.update(mined_global_parameters)
+
+        # Append the mined global parameters for installation
+        if len(global_parameters) > 0:
+            global_parameters['parameter_level'] = 'global'
+            new_parameters_list.append(global_parameters)
+
         return(new_parameters_list)
 
-    def read_parameter_file (self, filename):
+    def read_parameter_file(self, filename):
         """Method to read a single parameter file from a filename. This method can be extended to address different
         file formats or mappings.
 
@@ -256,3 +227,94 @@ class input_manager:
                 sys.exit('Invalid parameter file format: ' + filename)
 
         return(new_parameters)
+
+    def map_parameters(self, parameters):
+        """Function to map parameters from older versions to the present version, all mappings are externally specified
+        in the relavent function.
+
+        :param parameters = the input parameter dictionary
+        :return returns the compliant parameters dictionary, and optionally mined global parameters
+        """
+        if 'version' not in parameters:
+            print('Warning: interpreting parameters as version 1.0 because version key was missing')
+            parameters['version'] = '1.0'
+
+        mined_global_parameters = {}
+        if parameters['version'] == '1.0':
+            parameters, mined_global_parameters = input_mapper_v1(parameters)
+
+        return(parameters, mined_global_parameters)
+
+    def parse_parameters(self, new_parameters_list):
+        """Method to parse and validate new parameters, perform type checking, and organize for simulation.
+
+        This first goes through the new parameters, sorts out the programs and orphaned methods (methods that are
+        not directly integrated to a program).
+
+        Programs are then addressed, consecutively adding them in, calling in any orphaned methods. Orphaned methods
+        can be used in multiple programs if desired.
+
+        :param new_parameters_list: a list of new parameter dictionaries
+
+        The self.simulation_variables variable is set
+        """
+        # First, validate and install the global parameters, saving the programs and orphaned methods for the next step
+        programs = []
+        orphan_methods = {}
+        for new_parameters in new_parameters_list:
+            # Address unsupplied parameter level
+            if 'parameter_level' not in new_parameters:
+                new_parameters['parameter_level'] = 'global'
+                print('Warning: parameter_level should be supplied to parameter files, LDAR-Sim interprets parameter'
+                      'files as global if unspecified')
+
+            if new_parameters['parameter_level'] == 'global':
+                if len(new_parameters['programs']) > 0:
+                    programs = programs + new_parameters.pop('programs')
+
+                check_types(self.global_parameters, new_parameters, omit_keys = ['programs', 'methods'])
+                self.simulation_parameters.update(new_parameters)
+
+            elif new_parameters['parameter_level'] == 'program':
+                check_types(self.program_parameters, new_parameters, omit_keys = ['methods'])
+
+                # Copy all default program parameters to build upon by calling update, then append
+                new_program = copy.deepcopy(self.program_parameters)
+                new_program.update(new_parameters)
+                programs.append(new_program)
+
+            elif new_parameters['parameter_level'] == 'method':
+                # Search for the methods in this definition, which will be defined as dictionaries
+                for i in new_parameters:
+                    if isinstance(new_parameters[i], dict):
+                        orphan_methods.update({i: new_parameters[i]})
+
+            else:
+                sys.exit('supplied parameter_level is not possible to parse')
+
+        # Second, install the programs, checking for specified children methods
+        for program in programs:
+            # Find any orphaned methods that can be installed in this program
+            if 'method_names' in program:
+                for method_name in program['method_names']:
+                    method_found = False
+                    for i in orphan_methods:
+                        if method_name == i:
+                            program['methods'].update({i: copy.deepcopy(orphan_methods[i])})
+                            method_found = True
+
+                    if not method_found:
+                        print('Warning, the following method was specified by not supplied ' + method_name)
+
+            # Next, perform type checking and updating from default types, even for methods pre-specified
+            for i in program['methods']:
+                method_type = program['methods'][i]['type']
+                check_types(self.method_parameters[method_type], program['methods'][i])
+                new_method = copy.deepcopy(self.method_parameters[method_type])
+
+                # update from the default version, and re-assign
+                new_method.update(program['methods'][i])
+                program['methods'][i] = new_method
+
+        # Third, append the parameters to the global parameters
+        self.simulation_parameters['programs'] = programs

--- a/LDAR_Sim/model_code/input_manager.py
+++ b/LDAR_Sim/model_code/input_manager.py
@@ -1,0 +1,236 @@
+# ------------------------------------------------------------------------------
+# Program:     The LDAR Simulator (LDAR-Sim)
+# File:        LDAR-Sim input manager
+# Purpose:     Interface for managing, validating, and otherwise dealing with parameters
+#
+# Copyright (C) 2018-2020  Thomas Fox, Mozhou Gao, Thomas Barchyn, Chris Hugenholtz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the MIT License as published
+# by the Free Software Foundation, version 3.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+
+# You should have received a copy of the MIT License
+# along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+#
+# ------------------------------------------------------------------------------
+import copy
+import os
+import yaml
+import json
+import glob
+import sys
+
+def check_types (default, test, omit_keys = [], fatal = False):
+    """Helper function to recursively check the type of parameter dictionaries
+
+    :param default: default element to test
+    :param test: test element to test
+    :omit_keys: a list of dictionary keys to omit from further recursive testing
+    :param fatal: boolean to control whether sys.exit() is called upon a error
+    """
+    if type(default) is type(test):
+        # proceed to test for dict or list types to recursively examine
+        if isinstance(test, dict):
+            for i in test:
+                if not i in omit_keys:
+                    if not i in default:
+                        print('Key ' + i + ' present in test parameters, but not in default parameters')
+                        if fatal:
+                            sys.exit()
+
+                    else:
+                        check_types(default[i], test[i], fatal)
+
+        elif isinstance(test, list):
+            if len(test) > 0:
+                for i in range(len(test)):
+                    check_types(default[0], test[i], fatal)
+
+    else:
+        print('Parameter type mismatch')
+        print('Default parameter: ' + str(default) + ' is ' + type(default))
+        print('Test parameter: ' + str(test) + ' is ' + type(test))
+        if fatal:
+            sys.exit()
+
+class input_manager:
+    def __init__ (self, global_parameter_filename = '..//inputs_template//global_parameters.txt',
+                  program_parameter_filenames = None):
+        """ Constructor loads the input parameters in a format that is compliant with the internals of LDAR-Sim. These
+        parameters are subsequently modified by one or more input parameters.
+
+        First, this creates a default 'program' that contains all possible 'program' parameters. No input program can
+        contain parameters that do not exist in this default program.
+
+        Then, this creates a library of 'methods' that have unique parameter sets. For example, the aircraft method
+        can have different parameters than the truck method. But the P_aircraft and P_truck programs must have the
+        same parameters (with the exception of the methods, which can have non-unique parameters). When constructing a
+        new program, the methods must have appropriate tags to look up the default parameters for the methods involved.
+
+        The format of the default parameters is .txt, or .py, that gets read, and executed directly as
+        python code. This is to ensure reverse compatibility with the existing set of parameters and also to ensure
+        that the type are explicitly set with python code, where type setting is easier to understand and less subject
+        to possible issues with json or yaml parsers inferring incorrect types.
+
+        :param global_parameter_filename: filename for global parameters. Defaults to
+            '..//inputs_template//global_parameters.txt'
+        :param program_parameter_filenames: a list of default parameter files that represent the number of possible
+            programs. If missing, the '..//inputs_template//' directory is searched for files with a pattern of
+            'P_*.txt', which is the default naming convention in present use. NOTE: programs must be defined in
+            these default files as a dictionary where the object defined is IDENTICAL to the name of the file without
+            an exception. For example:
+
+            P_aircraft = {
+                # P_Aircraft parameters go here
+            }
+
+            Must be inside a file called P_aircraft.txt, or P_aircraft.py. There are no possible exceptions to this
+            rule presently.
+
+        This sets three class variables to represent default parameters:
+        self.global_parameters = all global parameters as a dictionary
+        self.program_parameters = all program parameters as a dictionary
+        self.method_parameters = a dictionary where the names refer to all possible methods
+        """
+
+        # Check if program parameter filenames were supplied, else try to read them in
+        if program_parameter_filenames is None:
+            program_parameter_filenames = glob.glob('..//inputs_template//P_*.txt')
+
+        # Read in default parameters
+        # 1) read in global parameters, this sets a local variable called 'parameters'
+        with open(global_parameter_filename, 'r') as f:
+            exec(f.read())
+
+        # 2) read in the program definitions, which contain method definitions
+        for parameter_filename in program_parameter_filenames:
+            with open(parameter_filename, 'r') as f:
+                program_definition, _ = os.path.splitext(os.path.basename(parameter_filename))
+                exec(f.read())
+                if not program_definition in locals():
+                    print(program_definition + ' is not defined in ' + parameter_filename)
+
+                parameters['programs'].append(eval(program_definition))
+
+        # 3) separate programs from methods and construct a default program with all possible parameters. This
+        #    accumulates a list of method definitions from the programs to conflate to a unique list of method
+        #    definitions.
+        self.program_parameters = {'methods': []}
+        temp_methods = []
+        for program in parameters['programs']:
+            temp_methods.append(program.pop['methods'])
+            self.program_parameters.update(program)
+
+        # 4) accumulate the method parameters so there is a dictionary of possible method types, each with all
+        #    known parameters, in a default and completely defined format
+        self.method_parameters = {}
+        for method_samples in temp_methods:
+            self.method_parameters.update(method_samples)
+
+        # 5) set default global parameters, programs and methods are dealt with separately
+        parameters['programs'] = []
+        self.global_parameters = parameters
+        return
+
+    def read_and_validate_parameters (self, parameter_filenames):
+        """Method to read and validate parameters
+        :param parameter_filenames: a list of paths to parameter files
+        :return returns fully validated parameters dictionary for simulation in LDAR-Sim
+        """
+        unvalidated_parameters = self.read_parameter_files(parameter_filenames)
+        validated_parameters = self.parse_parameters(unvalidated_parameters)
+        return(validated_parameters)
+
+    def parse_parameters (self, new_parameters_list):
+        """Method to parse and validate new parameters, perform type checking, and organize for simulation.
+
+        This first goes through the new parameters, sorts out the programs and orphaned methods (methods that are
+        not directly integrated to a program).
+
+        Programs are then addressed, consecutively adding them in, calling in any orphaned methods. Orphaned methods
+        can be used in multiple programs if desired.
+
+        :param new_parameters_list: a list of new parameter dictionaries
+        :return returns the validated parameters
+        """
+        # First, validate and install the global parameters, saving the programs and orphaned methods for the next step
+        programs = []
+        orphan_methods = []
+        for new_parameters in new_parameters_list:
+            # Address unsupplied
+            if not 'parameter_level' in new_parameters:
+                new_parameters['parameter_level'] = 'global'
+                print('Warning: parameter_level should be supplied to parameter files, LDAR-Sim interprets parameter'
+                      'files as global if unspecified')
+
+            if new_parameters['parameter_level'] == 'global':
+                programs.append(new_parameters.pop('programs'))
+                check_types(self.global_parameters, new_parameters, omit_keys = ['programs', 'methods'])
+                self.global_parameters.update(new_parameters)
+            elif new_parameters['parameter_level'] == 'program':
+                check_types(self.program_parameters, new_parameters, omit_keys = ['methods'])
+                programs.append(new_parameters)
+            elif new_parameters['parameter_level'] == 'method':
+                orphan_methods.append(new_parameters)
+
+        # Second, install the programs, checking for specified children methods
+        for program in programs:
+            # Find any orphaned children
+            if 'children_names' in program:
+                for children in program['children_names']:
+                    child_found = False
+                    for orphan in orphan_methods:
+                        if 'name' in orphan and orphan['name'] == children:
+                            program['methods'].update(copy.deepcopy(orphan))
+                            child_found = True
+
+                    if not child_found:
+                        print('Warning, the following child method was specified by not supplied ' + children)
+
+            # Next, perform type checking on the methods to ensure the supplied methods are compliant
+            for method in program['methods']:
+                method_type
+                check_types(self.method_parameters[method_name], program['methods'][method_name])
+
+        # Third, append the parameters to the global parameters and return
+        self.global_parameters['programs'] = programs
+        return(self.global_parameters)
+
+    def read_parameter_files (self, parameter_filenames):
+        """Method to read a collection of parameter files
+        :param parameter_filenames: a list of paths to parameter files
+        :return returns a list of parameter dictionaries
+        """
+        new_parameters_list = []
+        for parameter_filename in parameter_filenames:
+            new_parameters_list.append(self.read_parameter_file(parameter_filename))
+
+        return(new_parameters_list)
+
+    def read_parameter_file (self, filename):
+        """Method to read a single parameter file from a filename. This method can be extended to address different
+        file formats or mappings.
+
+        :param filename: the path to the parameter file
+        :return: dictionary of parameters read from the parameter file
+        """
+        parameter_set_name, extension = os.path.splitext(os.path.basename(filename))
+        new_parameters = {}
+        with open(filename, 'r') as f:
+            print('Reading ' + filename)
+            if extension == '.txt':
+                exec(f.read())
+                new_parameters.update(eval(parameter_set_name))
+            elif extension == '.json':
+                new_parameters = json.loads(f.read())
+            elif extension == '.yaml' or extension == '.yml':
+                new_parameters = yaml.load(f.read(), Loader = yaml.FullLoader)
+            else:
+                sys.exit('Invalid parameter file format: ' + filename)
+
+        return(new_parameters)

--- a/LDAR_Sim/model_code/input_mapper_v1.py
+++ b/LDAR_Sim/model_code/input_mapper_v1.py
@@ -1,0 +1,100 @@
+# ------------------------------------------------------------------------------
+# Program:     The LDAR Simulator (LDAR-Sim)
+# File:        LDAR-Sim input manager
+# Purpose:     Input mapper for version 1.0 files
+#
+# Copyright (C) 2018-2020  Thomas Fox, Mozhou Gao, Thomas Barchyn, Chris Hugenholtz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the MIT License as published
+# by the Free Software Foundation, version 3.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+
+# You should have received a copy of the MIT License
+# along with this program.  If not, see <https://opensource.org/licenses/MIT>.
+#
+# ------------------------------------------------------------------------------
+
+def input_mapper_v1(parameters):
+    """Function to perform all input mapping from version 1.0 parameter files to presently compliant parameter files. This is
+    necessary to ensure reverse compatibility - to allow older parameter files to run properly.
+
+    This function is a series of hooks that fall into several categories:
+    1) Construction hooks: these hooks construct newer parameters from older parameters. This is necessary if parameters
+    were depreciated in the newest version of the model, but relied upon in older versions. For example, newer versions
+    of the program may simply allow specification of a start and end date, but not include specification of the
+    number of timesteps. To allow this, a construction hook could create start and end date from the number of
+    timesteps using any necessary rules to maintain compatibility.
+
+    2) Destruction hooks: these hooks destruct parameters that are no longer in the default set of parameters in the
+    model. To continue the above example, if the present version of the model does not use number of timesteps, and
+    the number of timesteps is no longer specified in the default parameter file - that key should be removed. The issue
+    here is without destruction of depreciated parameters - this parameter file will fail validation. Of course,
+    destruction must be called AFTER construction so the information in the depreciated parameters is used to map
+    to the new parameters before being deleted!
+
+    3) Recalculation hooks: these hooks recalculate variables or map the values. For example, if the units have
+    changed, but the key has not - these hooks are necessary to recalculate the new units to be compliant with the
+    present version of the model. If the older version of the model had a spelling mistake in a string specification,
+    this type of hook would map the parameters. Several examples:
+
+    # map a old spelling mistake properly - the present version of LDAR Sim has corrected the spelling mistake but
+    # old parameter files continue to use the misspelled value
+    if parameters['calculation_method'] == 'categoricle':
+        parameters['calculation_method'] = 'categorical'
+
+    # map the leak rate parameter from one unit to another, the newest version uses a different unit, where 0.003332 is
+    # the conversion factor
+    parameters['leak_rate] = parameters['leak_rate'] * 0.003332
+
+    4) Key-change hooks: these hooks change the key name to a new key name to map the old name to the new name.
+
+    :param parameters = a dictionary of parameters that must be mapped to a compliant version
+    :return returns a model compliant parameter file dictionary and global parameter file (see notes in code).
+        In cases where the global parameters are not returned, the global parameters are returned as an empty dictionary
+    """
+    # --------------------------------------------------------------------------------------------------
+    # 1. Construction hooks
+    # NOTES: Version 1.0 parameter files used to create global parameters by pulling some parameters from
+    #        the P_ref program. Thus, this function returns global parameters as well as the parameters dictionary
+    #        under analysis. There were no global parameters in v1.0. They were defined inline in the code.
+
+    # Version 1.0 files are all program files
+    if 'parameter_level' not in parameters:
+        parameters['parameter_level'] = 'program'
+
+    # Set version
+    if 'version' not in parameters:
+        parameters['version'] = '1.0'
+
+    # Check if this is P_ref, if so, mine the global parameters
+    mined_global_parameters = {}
+    parameters_to_make_global = ['n_simulations', 'timesteps', 'start_year', 'weather_file',
+                                 'print_from_simulations', 'write_data']
+    if parameters['program_name'] == 'P_ref':
+        for i in parameters_to_make_global:
+            mined_global_parameters[i] = parameters[i]
+
+        # Construct a programs key
+        mined_global_parameters['programs'] = []
+
+    # --------------------------------------------------------------------------------------------------
+    # 2. Destruction hooks
+    # Delete the parameters that are now globals from this program definition - these do nothing
+    for i in parameters_to_make_global:
+        _ = parameters.pop(i)
+
+    # --------------------------------------------------------------------------------------------------
+    # 3. Recalculation hooks
+    pass
+
+    # --------------------------------------------------------------------------------------------------
+    # 4. Key-change hooks
+    pass
+
+    return(parameters, mined_global_parameters)
+

--- a/LDAR_Sim/model_code/input_mapper_v1.py
+++ b/LDAR_Sim/model_code/input_mapper_v1.py
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Program:     The LDAR Simulator (LDAR-Sim)
-# File:        LDAR-Sim input manager
+# File:        LDAR-Sim input mapper for version 1.0 files
 # Purpose:     Input mapper for version 1.0 files
 #
 # Copyright (C) 2018-2020  Thomas Fox, Mozhou Gao, Thomas Barchyn, Chris Hugenholtz

--- a/LDAR_Sim/model_code/ldar_sim_main.py
+++ b/LDAR_Sim/model_code/ldar_sim_main.py
@@ -22,8 +22,10 @@ from pathlib import Path
 
 from batch_reporting import BatchReporting
 from ldar_sim_run import ldar_sim_run
+from input_mapper import input_mapper
 import pandas as pd
 import os
+import sys
 import shutil
 import datetime
 import warnings
@@ -33,6 +35,12 @@ from generic_functions import check_ERA5_file
 if __name__ == '__main__':
     # ------------------------------------------------------------------------------
     # -----------------------------Global parameters--------------------------------
+    # Read default parameters
+    inputs = input_mapper()
+    print ('default parameters read')
+
+
+
     src_dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
     src_dir = str(src_dir_path)
     root_dir = str(src_dir_path.parent)

--- a/LDAR_Sim/sample_simulations/OGI.yaml
+++ b/LDAR_Sim/sample_simulations/OGI.yaml
@@ -1,0 +1,5 @@
+parameter_level: method
+version: '2.0'
+OGI:
+  type: OGI
+    

--- a/LDAR_Sim/sample_simulations/P_ref.yaml
+++ b/LDAR_Sim/sample_simulations/P_ref.yaml
@@ -1,0 +1,5 @@
+program_name: P_ref
+parameter_level: program
+version: '2.0'
+method_names:
+- OGI


### PR DESCRIPTION
## Linked issues / PRs

Replaces #7  
Warns loudly about #72 
Addresses #71 
Addresses #59 
Probably related to #55 
Probably kills #34 
Sets the infrastructure for #29 
Sets the infrastructure for #17 

## Overview

This set of improvements is an attempt to create infrastructure for a more pleasurable relationship with parameters. It does not significantly modify parameters themselves, I know there has been a lot of suggestions for revisions to parameter names, or clean up things here and there to simplify, but this PR only focuses on infrastructure. I've put the 'global' parameters that were inline in `ldar_sim_main.py` into a file called `global_parameters.txt`, but have not brought anything else out from the existing program definitions as globals. This work is outstanding, but probably better done separately to this PR - with appropriate mappings set up to maintain a little bit of reverse compatibility.

## Why?

Here are the basic motivations for improvements in the parameter experience:

1. Some parameters are specified in the code - stylistically it is better if the code exists without the parameters. It also cleans up issues with version control, parameters are totally separate from the code, not subject to any licenses or anything and not caught up in git version control.
2. Program definitions had limitations to where they could be located on the file system - this was hard coded in the code - ideally parameter files and outputs can be anywhere.
3. Global parameters were mined from the 'P_ref' program, or whatever the first program definition was - this is OK if you know this, but is error prone. A global level parameters is needed for these simulation wide parameters.
4. Unused parameters existed in program definitions - this is confusing to users as modifying these parameters does nothing.
5. Reverse compatibility of new parameter files is limited. If a new parameter was added to the model, it must be added to all parameter files that have ever existed otherwise the model won't run.
6. Types of input parameters were not fixed. This is OK for just a python model where type inference is handled softly and usually not a problem, but if interacting with json, or databases, fixing types is important, particularly for Soroush. This matters a lot for lists, where they must all be the same type in json or databases, but can exist as a loose collection of objects natively in Python.
7. Some parameters have unique named keys, instead supplied in lists. Parameters in python lists were referenced by index within the list, this is less clear and harder to work with for users as one must remember the index, and must include all values in the list so the referencing works in the program. This is not really fixed, the program just complains about it in this PR.
8. There is a desire to use different file formats or excel spreadsheets - this needs a 'front door' for parameters to map them to whatever the model uses internally, validate them a lot before releasing to the model, the pursuit of the 'parameter mapper'
9. The web app must not write .txt files and execute them - the web app must write json files, or otherwise pass json parameters to the model due to security concerns with the executablity of .txt files interpreted as python code. Not a real issue for desktop use though.
10. Some parameters were modified by the program. This is a style thing that would be good to fix.
11. All the parameters need to be supplied to run the program - this leads to huge parameter files that must be up to date with the model and require significant learning to specify. Running simple simulations can thus be unnecessarily complex.
12. Parameter files had complex rules around formatting - e.g., 'P_ref.txt' must have a name key of P_ref, etc. Anything else does not work and does not provide feedback to the user why it doesn't work. This is an easy error to make. This is still not resolved for .txt parameter files, but not an issue for yaml or json inputs.
13. There was a lot of copying of parameters required to construct a 'treatment / control' simulations with identical control methods. This is a small thing - but it is error prone.

## How do new changes work?

1. All defined parameters in the inputs_template folder are read in to create master default parameter collections. There is a set of defaults for global parameters, a set of defaults for program parameters, and default parameters for each type of method.
2. Parameters are read in one at a time, from multiple parameter files, in either txt, yaml, or json format.
3. First global parameters are sorted out, and types are checked against the defaults. Not the same type? It throws and error, but in the future should probably crash. Supplied parameters are read on top of the defaults - all simulations run with full suite of parameters, always, with only the keys you want to change changed.
4. Second, program parameters are sorted out, setting out the programs in the simulation, same deal: type check and updating to all program parameters.
5. Third, methods are placed into each program, checking types against the different types of methods, type checking, and updating off the defaults.
6. Fourth, the parameter dictionary is written to the output folder, you can call this file as a parameter file and re-run the simulation if you please - but it updates the metadata in a better format.
6. Finally, the full parameter dictionary is released to the model and it proceeds to do what it did before.

## What are the problems with this?

- Complexity: it is complicated and the documentation needs a good study prior to getting started. Even still, it feels complex.
- Opaqueness: relying upon default parameters requires a lot more of an **iron hand** with new features. The defaults must set new features to be 'off' - and turned on as desired. New features and new parameters cannot change old results.
- Defaults: defaults must be rock solid and well thought out because you can run the model easy without ever seeing them.
- New parameters must map to maintain some reverse compatibility - there is a lot of care required changing parameters to maintain reverse compatiblity and without a doubt a test suite is required to automatically test that new features do not break old simulations and appropriately map through parameters. See the `input_mapper_v1.py` for some discussion on the challenges here.

## Can I use the old way of specifying parameters?

Yep. Just supply the `P_ref.txt`, `P_alt.txt`, style of files as arguments or hardcode it in the first few lines of the model. Ideally put your `P_ref.txt`, etc. in a different folder as the ones in `inputs_template` folder are the defaults now and should not be changed unless changing the actual model and defaults it runs with.

## How to test?

Without command line arguments the branch should run simple test simulation, defined by 2 very short parameter files in the `sample_simulations` directory:

First file defines the program to run, called `P_ref`
```
program_name: P_ref
parameter_level: program
version: '2.0'
method_names:
- OGI
```

Second file defines that OGI method referenced in the first file:

```
parameter_level: method
version: '2.0'
OGI:
  type: OGI
```

Every other parameter runs with default values. For more detailed explanation of how this works, refer to the input documentation - I tried to explain how things work with simple examples and how the modularity can be un-caged.

## Notes on parameter mapping

Mapping parameters, or more complex compatibility operations are actually rather complex and a large maintenance burden. I've started on this effort to try to support older parameter files, but refer to input_mapper_v1.py to see discussion and the various types of hooks that must be specified to map different structures of parameters to compliant formats.

## Is this tested?

Yes and no. I've tried to test most things, but I would not be surprised if there were a few gotchas in how this is set up.

