### PR TITLE
Uses sys.exit to crash the program

### DIFF
--- a/LDAR_Sim/src/initialization/args.py
+++ b/LDAR_Sim/src/initialization/args.py
@@ -55,6 +55,6 @@ def files_from_args():
 
     if len(parameter_filenames) < 1:
         print('Please provide at least one input argument')
-        sys.exit ()
-        
+        sys.exit()
+
     return parameter_filenames


### PR DESCRIPTION
This is a small change (possibly with big implications) - I don't want to break anything so making this a PR.

`sys.exit()` here should crash the program with no input arguments, after outputting the message that nothing was supplied.

The problem is that it will proceed with `exit` and fail deeper in the code in what looks like a bug, but actually was just there was no inputs supplied.
