### PR TITLE
Don't allow running with no programs

### DIFF
--- a/LDAR_Sim/src/initialization/input_manager.py
+++ b/LDAR_Sim/src/initialization/input_manager.py
@@ -175,6 +175,10 @@ class InputManager:
                 sys.exit('Parameter_level of ' + str(new_parameters['parameter_level']) +
                          ' is not possible to parse')
 
+        # Double check there is at least 1 program
+        if len(programs) == 0:
+            sys.exit('No programs are supplied')
+
         # Second, install the programs, checking for specified children methods
         for program in programs:
             # Find any orphaned methods that can be installed in this program


### PR DESCRIPTION
Running LDAR Sim with no programs crashes. This checks to make sure there is at least 1 program so it doesn't fail in site generation.

```
C:\Users\tom\.virtualenvs\src-9RtAWWXW\Scripts\python.exe D:/dev/LDAR_Sim_2/LDAR_Sim/src/ldar_sim_main.py ./simulations/G_.yaml
Reading ./simulations/G_.yaml

 --- 
 pregenerated data exists, do you want to use (y/n)? "n" will remove contents of generated data folder.
n
Traceback (most recent call last):
  File "D:/dev/LDAR_Sim_2/LDAR_Sim/src/ldar_sim_main.py", line 95, in <module>
    sites, leak_timeseries, initial_leaks = generate_sites(programs[0], input_directory)
IndexError: list index out of range

Process finished with exit code 1
```