### PR TITLE
Exit when parameter files cannot be found

### DIFF
--- a/LDAR_Sim/src/initialization/input_manager.py
+++ b/LDAR_Sim/src/initialization/input_manager.py
@@ -23,6 +23,7 @@ import copy
 import yaml
 import json
 import sys
+import os
 from pathlib import Path
 
 from utils.check_parameter_types import check_types
@@ -95,6 +96,13 @@ class InputManager:
         extension = param_file.suffix
 
         new_parameters = {}
+
+        if not os.path.exists(param_file):
+            print('Parameter file ' + str(param_file) + ' does not exist')
+            if not param_file.is_absolute():
+                print('Note that relative file paths must be relative to the root directory '
+                      '(see User Manual)')
+            sys.exit()
 
         with open(param_file, 'r') as f:
             print('Reading ' + filename)


### PR DESCRIPTION
This addresses 2 rough moments I had:
1. LDAR sim should crash when a supplied parameter file does not exist, but ... it may be softer on users to issue a message?
2. While its in the manual ... the way the working directory is immediately changed to one directly up from the src directory in ldar_sim_main.py to the 'root directory', is different than other programs, and tripped me up for a bit. Could a warning help here - I worry it will be a common mistake as specifying a parameter file with `../simulations/M_air.yaml` feels like the right arg, when in fact it is not.