### PR TITLE
JSON versions of input yamls

### DIFF
--- a/LDAR_Sim/simulations/G_.json
+++ b/LDAR_Sim/simulations/G_.json
@@ -1,0 +1,7 @@
+{
+    "parameter_level": "global",
+    "version": "2.0",
+    "pregenerate_leaks": true,
+    "preseed_random": true,
+    "make_maps": false
+}

--- a/LDAR_Sim/simulations/M_OGI.json
+++ b/LDAR_Sim/simulations/M_OGI.json
@@ -1,0 +1,22 @@
+{
+    "parameter_level": "method",
+    "version": "2.0",
+    "label": "OGI",
+    "module": "dummy",
+    "deployment_type": "mobile",
+    "measurement_scale": "component",
+    "sensor": {
+        "type": "OGI_camera",
+        "MDL": [
+            0.01275,
+            2.78e-06
+        ]
+    },
+    "is_follow_up": false,
+    "cost": {
+        "per_day": 2500
+    },
+    "t_bw_sites": {
+        "file": "time_offsite_ground.csv"
+    }
+}

--- a/LDAR_Sim/simulations/M_OGI_FU.json
+++ b/LDAR_Sim/simulations/M_OGI_FU.json
@@ -1,0 +1,22 @@
+{
+    "parameter_level": "method",
+    "version": "2.0",
+    "label": "OGI_FU",
+    "module": "dummy",
+    "deployment_type": "mobile",
+    "measurement_scale": "component",
+    "sensor": {
+        "type": "OGI_camera",
+        "MDL": [
+            0.01275,
+            2.78e-06
+        ]
+    },
+    "is_follow_up": true,
+    "cost": {
+        "per_day": 2500
+    },
+    "t_bw_sites": {
+        "file": "time_offsite_ground.csv"
+    }
+}

--- a/LDAR_Sim/simulations/M_aircraft.json
+++ b/LDAR_Sim/simulations/M_aircraft.json
@@ -1,0 +1,23 @@
+{
+    "parameter_level": "method",
+    "version": "2.0",
+    "label": "aircraft",
+    "module": "dummy",
+    "deployment_type": "mobile",
+    "measurement_scale": "equipment",
+    "sensor": {
+        "type": "default",
+        "MDL": [
+            0.01
+        ]
+    },
+    "is_follow_up": false,
+    "cost": {
+        "per_day": 10000
+    },
+    "t_bw_sites": {
+        "vals": [
+            10
+        ]
+    }
+}

--- a/LDAR_Sim/simulations/M_operator.json
+++ b/LDAR_Sim/simulations/M_operator.json
@@ -1,0 +1,20 @@
+{
+    "parameter_level": "method",
+    "version": "2.0",
+    "label": "operator",
+    "module": "dummy",
+    "deployment_type": "stationary",
+    "measurement_scale": "component",
+    "sensor": {
+        "type": "default",
+        "MDL": [
+            0.1
+        ]
+    },
+    "cost": {
+        "per_day": 0
+    },
+    "coverage": {
+        "spatial": 0.01
+    }
+}

--- a/LDAR_Sim/simulations/M_stationary.json
+++ b/LDAR_Sim/simulations/M_stationary.json
@@ -1,0 +1,22 @@
+{
+    "parameter_level": "method",
+    "version": "2.0",
+    "label": "stationary",
+    "module": "dummy",
+    "deployment_type": "stationary",
+    "measurement_scale": "equipment",
+    "sensor": {
+        "type": "default",
+        "MDL": [
+            0.5
+        ]
+    },
+    "is_follow_up": false,
+    "coverage": {
+        "temporal": 0.12
+    },
+    "cost": {
+        "upfront": 500,
+        "per_day": 1
+    }
+}

--- a/LDAR_Sim/simulations/P_OGI.json
+++ b/LDAR_Sim/simulations/P_OGI.json
@@ -1,0 +1,8 @@
+{
+    "program_name": "P_OGI",
+    "parameter_level": "program",
+    "version": "2.0",
+    "method_labels": [
+        "OGI"
+    ]
+}

--- a/LDAR_Sim/simulations/P_air.json
+++ b/LDAR_Sim/simulations/P_air.json
@@ -1,0 +1,9 @@
+{
+    "program_name": "P_air",
+    "parameter_level": "program",
+    "version": "2.0",
+    "method_labels": [
+        "aircraft",
+        "OGI_FU"
+    ]
+}

--- a/LDAR_Sim/simulations/P_none.json
+++ b/LDAR_Sim/simulations/P_none.json
@@ -1,0 +1,6 @@
+{
+    "program_name": "P_none",
+    "parameter_level": "program",
+    "version": "2.0",
+    "method_labels": []
+}

--- a/LDAR_Sim/simulations/P_stationary.json
+++ b/LDAR_Sim/simulations/P_stationary.json
@@ -1,0 +1,9 @@
+{
+    "program_name": "P_stationary",
+    "parameter_level": "program",
+    "version": "2.0",
+    "method_labels": [
+        "stationary",
+        "OGI_FU"
+    ]
+}

--- a/LDAR_Sim/src/default_parameters/g_default.json
+++ b/LDAR_Sim/src/default_parameters/g_default.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0",
+    "parameter_level": "global",
+    "input_directory": "./inputs",
+    "output_directory": "./outputs",
+    "n_processes": "_placeholder_int_",
+    "print_from_simulations": true,
+    "n_simulations": 2,
+    "write_data": true,
+    "make_plots": true,
+    "make_maps": true,
+    "programs": [],
+    "start_date": [
+        2017,
+        1,
+        1
+    ],
+    "end_date": [
+        2021,
+        12,
+        31
+    ],
+    "reference_program": "P_OGI",
+    "baseline_program": "P_none",
+    "pregenerate_leaks": false,
+    "preseed_random": false
+}

--- a/LDAR_Sim/src/default_parameters/m_default.json
+++ b/LDAR_Sim/src/default_parameters/m_default.json
@@ -1,0 +1,77 @@
+{
+    "consider_daylight": false,
+    "cost": {
+        "per_day": 2000,
+        "per_hour": 0,
+        "per_site": 0,
+        "upfront": 0
+    },
+    "coverage": {
+        "spatial": 1.0,
+        "temporal": 1.0
+    },
+    "deployment_type": "mobile",
+    "follow_up": {
+        "delay": 0,
+        "instant_threshold": "_placeholder_float_",
+        "instant_threshold_type": "absolute",
+        "interaction_priority": "threshold",
+        "proportion": 1.0,
+        "redundancy_filter": "recent",
+        "threshold": 0.0,
+        "threshold_type": "absolute"
+    },
+    "is_follow_up": false,
+    "label": "mobile",
+    "max_workday": 8,
+    "measurement_scale": "equipment",
+    "module": "dummy",
+    "n_crews": "_placeholder_int_",
+    "parameter_level": "method",
+    "reporting_delay": 2,
+    "scheduling": {
+        "deployment_months": [
+            "_placeholder_int_"
+        ],
+        "deployment_years": [
+            "_placeholder_int_"
+        ],
+        "LDAR_crew_init_location": [
+            -114.062,
+            51.044
+        ],
+        "home_bases_files": "Airport_AB_Coordinates.csv",
+        "route_planning": false,
+        "travel_speeds": [
+            "_placeholder_int_"
+        ]
+    },
+    "sensor": {
+        "type": "default",
+        "QE": 0.0,
+        "MDL": [
+            0.01
+        ]
+    },
+    "t_bw_sites": {
+        "file": "_placeholder_str_",
+        "vals": [
+            30
+        ]
+    },
+    "weather_envs": {
+        "precip": [
+            0.0,
+            0.5
+        ],
+        "temp": [
+            -30.0,
+            40.0
+        ],
+        "wind": [
+            0.0,
+            10.0
+        ]
+    },
+    "version": "2.0"
+}

--- a/LDAR_Sim/src/default_parameters/p_default.json
+++ b/LDAR_Sim/src/default_parameters/p_default.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.0",
+    "parameter_level": "program",
+    "methods": {},
+    "method_labels": [],
+    "program_name": "default",
+    "weather_file": "ERA5_AB_lowres_2015_2020.nc",
+    "weather_is_hourly": false,
+    "infrastructure_file": "facility_list_template.csv",
+    "site_samples": 50,
+    "subtype_times_file": "_placeholder_str_",
+    "consider_weather": false,
+    "repair_delay": 14,
+    "emissions": {
+        "consider_venting": false,
+        "leak_dist_params": [
+            -2.776,
+            1.462
+        ],
+        "leak_dist_type": "lognorm",
+        "leak_file": "_placeholder_str_",
+        "leak_file_use": "sample",
+        "LPR": 0.0065,
+        "max_leak_rate": 1000.0,
+        "subtype_leak_dist_file": "_placeholder_str_",
+        "units": [
+            "kilogram",
+            "hour"
+        ],
+        "vent_file": "site_rates.csv"
+    },
+    "NRd": 150,
+    "economics": {
+        "carbon_price_tonnesCO2e": 40.0,
+        "cost_CCUS": 20.0,
+        "GWP_CH4": 28.0,
+        "sale_price_natgas": 3.0,
+        "repair_costs": {
+            "vals": [
+                200
+            ],
+            "file": "_placeholder_str_"
+        },
+        "verification_cost": 25
+    }
+}


### PR DESCRIPTION
I don't know if this should be merged or just curated some other way.

Issues:
1. No examples are available in json format.
2. @soroushojagh requires json versions of input files to use as templates for web app.

This just makes json versions of the existing input files, defaults included. This does not address the general issue of having more sample inputs in general terms.
